### PR TITLE
Reutilización de contador de turnos para descuento

### DIFF
--- a/__tests__/lib/discount.test.ts
+++ b/__tests__/lib/discount.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import {
+  getDiscountCycle,
+  isThisTurnEligible,
+  turnsUntilNextDiscount,
+  applyDiscountIfEligible,
+} from "../../src/BACK/lib/discount";
+
+describe("discount helper", () => {
+  describe("getDiscountCycle", () => {
+    it("returns null for unknown category", () => {
+      expect(getDiscountCycle(null)).toBeNull();
+      expect(getDiscountCycle("Inicial")).toBeNull();
+    });
+
+    it("returns correct cycle for Medium and Premium", () => {
+      expect(getDiscountCycle("Medium")).toBe(4);
+      expect(getDiscountCycle("Premium")).toBe(6);
+    });
+  });
+
+  describe("isThisTurnEligible", () => {
+    it("returns true when (count+1) is multiple of cycle", () => {
+      expect(isThisTurnEligible(3, 4)).toBe(true); // 4th
+      expect(isThisTurnEligible(4, 6)).toBe(false);
+      expect(isThisTurnEligible(5, 6)).toBe(true); // 6th
+      expect(isThisTurnEligible(11, 6)).toBe(true); // 12th
+    });
+  });
+
+  describe("turnsUntilNextDiscount", () => {
+    it("calculates remaining turns correctly", () => {
+      expect(turnsUntilNextDiscount(3, 4)).toBe(0);
+      expect(turnsUntilNextDiscount(2, 4)).toBe(1);
+      expect(turnsUntilNextDiscount(0, 4)).toBe(3);
+    });
+  });
+
+  describe("applyDiscountIfEligible", () => {
+    it("applies discount when eligible and returns applied=true", () => {
+      const res = applyDiscountIfEligible(100, 20, 3, 4);
+      expect(res.applied).toBe(true);
+      expect(res.precioFinal).toBeCloseTo(80);
+    });
+
+    it("does not apply discount when not eligible", () => {
+      const res = applyDiscountIfEligible(100, 20, 2, 4);
+      expect(res.applied).toBe(false);
+      expect(res.precioFinal).toBe(100);
+    });
+
+    it("handles 100% discount as zero price", () => {
+      const res = applyDiscountIfEligible(150, 100, 3, 4);
+      expect(res.applied).toBe(true);
+      expect(res.precioFinal).toBe(0);
+    });
+  });
+});

--- a/src/BACK/Appointments/Appointments.ts
+++ b/src/BACK/Appointments/Appointments.ts
@@ -2,6 +2,7 @@ import { prisma, DatabaseError, sanitizeInput } from "../base/Base"; // importam
 import { z } from "zod";
 import { AppointmentSchema } from "../Schemas/appointmentsSchema";
 import { billAppointment } from "../billing/Billing";
+import { getDiscountCycle, applyDiscountIfEligible } from "../lib/discount";
 
 // Umbrales configurables (pueden ser sobreescritos por env vars durante pruebas)
 const INITIAL_TO_MEDIUM_DAYS = parseInt(
@@ -864,22 +865,20 @@ export const checkoutAppointment = async (
           },
         });
 
-        // incluir el turno actual en el conteo para evaluar si corresponde el descuento
-        const cobradoCountConEsteTurno = cobradoCount + 1;
+        const categoriaNombre = latestCategory.nombreCategoria || null;
+        const cycle = getDiscountCycle(categoriaNombre);
 
-        let cycle = 0;
-        const categoriaNombre = latestCategory.nombreCategoria || "";
-        if (categoriaNombre === "Medium") cycle = 4;
-        else if (categoriaNombre === "Premium") cycle = 6;
+        const { precioFinal: appliedPrice, applied } = applyDiscountIfEligible(
+          precioTurno,
+          latestCategory.descuentoCorte,
+          cobradoCount,
+          cycle,
+        );
 
-        if (cycle > 0 && cobradoCountConEsteTurno % cycle === 0) {
-          const descuentoCorte = latestCategory.descuentoCorte;
-          precioFinal =
-            descuentoCorte >= 100
-              ? 0
-              : precioTurno * (1 - descuentoCorte / 100);
+        if (applied) {
+          precioFinal = appliedPrice;
           console.log(
-            `Aplicando descuento de ${descuentoCorte}% - Precio original: ${precioTurno}, Precio final: ${precioFinal}`,
+            `Aplicando descuento de ${latestCategory.descuentoCorte}% - Precio original: ${precioTurno}, Precio final: ${precioFinal}`,
           );
         }
       }

--- a/src/BACK/lib/discount.ts
+++ b/src/BACK/lib/discount.ts
@@ -1,0 +1,36 @@
+export const getDiscountCycle = (nombreCategoria: string | null | undefined): number | null => {
+  if (!nombreCategoria) return null;
+  if (nombreCategoria === "Medium") return 4;
+  if (nombreCategoria === "Premium") return 6;
+  return null;
+};
+
+export const isThisTurnEligible = (countSinceStart: number, cycle: number | null): boolean => {
+  if (!cycle || cycle <= 0) return false;
+  return ((countSinceStart + 1) % cycle) === 0;
+};
+
+export const turnsUntilNextDiscount = (countSinceStart: number, cycle: number | null): number | null => {
+  if (!cycle || cycle <= 0) return null;
+  return (cycle - ((countSinceStart + 1) % cycle)) % cycle;
+};
+
+export const applyDiscountIfEligible = (
+  precioBase: number,
+  descuentoCorte: number,
+  countSinceStart: number,
+  cycle: number | null,
+): { precioFinal: number; applied: boolean } => {
+  if (!cycle || cycle <= 0) return { precioFinal: precioBase, applied: false };
+  const eligible = isThisTurnEligible(countSinceStart, cycle);
+  if (!eligible) return { precioFinal: precioBase, applied: false };
+  const precioFinal = descuentoCorte >= 100 ? 0 : precioBase * (1 - descuentoCorte / 100);
+  return { precioFinal, applied: true };
+};
+
+export default {
+  getDiscountCycle,
+  isThisTurnEligible,
+  turnsUntilNextDiscount,
+  applyDiscountIfEligible,
+};

--- a/src/BACK/users/Users.ts
+++ b/src/BACK/users/Users.ts
@@ -2,6 +2,11 @@ import { prisma, DatabaseError, sanitizeInput } from "../base/Base";
 import { z } from "zod";
 import { hashPassword, comparePassword } from "../users/bcrypt";
 import { UserSchema, UserBaseSchemaExport } from "../Schemas/usersSchema";
+import {
+  getDiscountCycle,
+  turnsUntilNextDiscount as calcTurnsUntilNextDiscount,
+  isThisTurnEligible,
+} from "../lib/discount";
 
 const INITIAL_TO_MEDIUM_DAYS = parseInt(
   process.env.INITIAL_TO_MEDIUM_DAYS || "30",
@@ -67,36 +72,42 @@ const buildLoyaltyProgress = async (
   });
 
   const now = new Date();
-  const totalMs = thresholdDate ? Math.max(thresholdDate.getTime() - startDate.getTime(), 0) : 0;
+  const totalMs = thresholdDate
+    ? Math.max(thresholdDate.getTime() - startDate.getTime(), 0)
+    : 0;
   const elapsedMs = thresholdDate
     ? Math.min(Math.max(now.getTime() - startDate.getTime(), 0), totalMs)
     : 0;
 
   const timeProgress = totalMs > 0 ? elapsedMs / totalMs : 1;
-  const countProgress = countRequired && countRequired > 0 ? Math.min(countCurrent / countRequired, 1) : 1;
+  const countProgress =
+    countRequired && countRequired > 0
+      ? Math.min(countCurrent / countRequired, 1)
+      : 1;
   const progress = nextCategory ? Math.min(timeProgress, countProgress) : null;
   const daysRequired = totalMs > 0 ? Math.ceil(totalMs / MS_PER_DAY) : null;
   const daysCurrent = totalMs > 0 ? Math.floor(elapsedMs / MS_PER_DAY) : null;
 
   // Calcular ciclo de descuento para la categoría actual (si aplica)
-  let discountCycle: number | null = null;
-  if (nombreCategoria === "Medium") discountCycle = 4;
-  else if (nombreCategoria === "Premium") discountCycle = 6;
+  const discountCycle = getDiscountCycle(nombreCategoria);
 
   let turnsUntilNextDiscount: number | null = null;
   let discountProgress: number | null = null;
+  let isThisTurnEligibleFlag: boolean | null = null;
 
   if (discountCycle && typeof countCurrent === "number") {
-    // contar cuántos turnos faltan hasta el próximo turno que recibirá descuento
-    // Nota: en el backend al cobrar se utiliza (count + 1) para evaluar si el turno actual
-    // corresponde al múltiplo del ciclo. Para la UI calculamos cuántos turnos faltan
-    // antes de que un turno futuro (incluyendo el próximo) sea elegible.
-    turnsUntilNextDiscount =
-      (discountCycle - ((countCurrent + 1) % discountCycle)) % discountCycle;
+    turnsUntilNextDiscount = calcTurnsUntilNextDiscount(
+      countCurrent,
+      discountCycle,
+    );
     discountProgress =
       discountCycle > 0
-        ? Math.round(((discountCycle - turnsUntilNextDiscount) / discountCycle) * 100) / 100
+        ? Math.round(
+            ((discountCycle - (turnsUntilNextDiscount ?? 0)) / discountCycle) *
+              100,
+          ) / 100
         : null;
+    isThisTurnEligibleFlag = isThisTurnEligible(countCurrent, discountCycle);
   }
 
   return {
@@ -113,6 +124,7 @@ const buildLoyaltyProgress = async (
     discountCycle,
     turnsUntilNextDiscount,
     discountProgress,
+    isThisTurnEligible: isThisTurnEligibleFlag,
   };
 };
 

--- a/src/FRONT/views/components/Barber/appointments/branchAppointments.tsx
+++ b/src/FRONT/views/components/Barber/appointments/branchAppointments.tsx
@@ -53,6 +53,8 @@ const CheckoutForm: React.FC<{
   const [descuentoInfo, setDescuentoInfo] = useState<{
     descuento: number;
     nombreCategoria: string;
+    turnsUntilNextDiscount?: number | null;
+    isThisTurnEligible?: boolean | null;
   } | null>(null);
   const [loadingCategoria, setLoadingCategoria] = useState(true);
   const loadedClientRef = useRef<string | null>(null);
@@ -77,6 +79,9 @@ const CheckoutForm: React.FC<{
               descuento: userData.categoriaActual.descuentoCorte || 0,
               nombreCategoria:
                 userData.categoriaActual.nombreCategoria || "Sin categoría",
+              turnsUntilNextDiscount:
+                userData.loyaltyProgress?.turnsUntilNextDiscount ?? null,
+              isThisTurnEligible: userData.loyaltyProgress?.isThisTurnEligible ?? null,
             });
             console.log(
               `✅ Categoría cargada: ${userData.categoriaActual.nombreCategoria} - Descuento: ${userData.categoriaActual.descuentoCorte}%`,
@@ -330,13 +335,14 @@ const CheckoutForm: React.FC<{
   }, [watchedCodCorte, allCortes, setValue]);
 
   // Calcular precio final con descuento
+  // Aplicar descuento solo si la categoría aplica Y este turno es elegible
   const precioFinal =
-    descuentoInfo && descuentoInfo.descuento > 0
+    descuentoInfo && descuentoInfo.descuento > 0 && descuentoInfo.isThisTurnEligible
       ? watchedPrecio * (1 - descuentoInfo.descuento / 100)
       : watchedPrecio;
 
   const descuentoAplicado =
-    descuentoInfo && descuentoInfo.descuento > 0
+    descuentoInfo && descuentoInfo.descuento > 0 && descuentoInfo.isThisTurnEligible
       ? watchedPrecio - precioFinal
       : 0;
 
@@ -380,7 +386,7 @@ const CheckoutForm: React.FC<{
               </span>
             </div>
 
-            {descuentoInfo && descuentoInfo.descuento > 0 && (
+            {descuentoInfo && descuentoInfo.descuento > 0 && descuentoInfo.isThisTurnEligible && (
               <>
                 <div className={styles.categoryBadge}>
                   <span className={styles.categoryName}>


### PR DESCRIPTION
- Nuevo helper para calcular progreso hasta el prox descuento
- Arreglo front de branchAppointments para que solo muestre el descuento cuando es aplicable para ese turno