### PR TITLE
Agregar utilidades para fechas de turnos

### DIFF
--- a/src/FRONT/views/components/Barber/appointments/barberAppointments.tsx
+++ b/src/FRONT/views/components/Barber/appointments/barberAppointments.tsx
@@ -5,7 +5,12 @@ import toast from "react-hot-toast";
 import { useNavigate } from "react-router-dom";
 import TimeSlotPicker from "../../shared/TimeSlotPicker";
 import type { AppointmentFull } from "../../shared/appointments";
-import { formatDate, formatTime } from "../../shared/appointments";
+import {
+  formatDate,
+  formatTime,
+  sortTurnosByDateTime,
+  unwrapAppointments,
+} from "../../shared/appointments";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
@@ -19,7 +24,7 @@ const BarberAppointments: React.FC = () => {
   const { user, isAuthenticated } = useAuth();
   const [turnos, setTurnos] = useState<AppointmentFull[]>([]);
   const [statusFilter, setStatusFilter] = useState<string>("Todos");
-  const [dateSort, setDateSort] = useState<string>("desc");
+  const [dateSort, setDateSort] = useState<"asc" | "desc">("desc");
   const [authChecked, setAuthChecked] = useState(false);
   const [isLoadingTurnos, setIsLoadingTurnos] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -118,16 +123,7 @@ const BarberAppointments: React.FC = () => {
         const data = await res.json().catch(() => null);
 
         console.log("Turnos data:", data);
-        // El backend puede devolver { success: true, data: [...] } o directamente un array
-        let turnosArray: AppointmentFull[] = [];
-
-        if (data) {
-          if (data.success && Array.isArray(data.data)) {
-            turnosArray = data.data;
-          } else if (Array.isArray(data)) {
-            turnosArray = data;
-          }
-        }
+        const turnosArray = unwrapAppointments<AppointmentFull>(data);
 
         console.log("Turnos array procesado:", turnosArray);
         setTurnos(turnosArray);
@@ -357,7 +353,9 @@ const BarberAppointments: React.FC = () => {
         <select
           className={barberStyles.filterSelect}
           value={dateSort}
-          onChange={(e) => setDateSort(e.target.value)}
+          onChange={(e) =>
+            setDateSort(e.target.value as "asc" | "desc")
+          }
         >
           <option value="desc">Lejanos primero</option>
           <option value="asc">Próximos primero</option>
@@ -375,13 +373,7 @@ const BarberAppointments: React.FC = () => {
             .filter(
               (t) => statusFilter === "Todos" || t.estado === statusFilter,
             )
-            .sort((a, b) => {
-              const strA = `${a.fechaTurno.split("T")[0]}T${formatTime(a.horaDesde)}`;
-              const strB = `${b.fechaTurno.split("T")[0]}T${formatTime(b.horaDesde)}`;
-              return dateSort === "desc"
-                ? strB.localeCompare(strA)
-                : strA.localeCompare(strB);
-            })
+            .sort((a, b) => sortTurnosByDateTime(a, b, dateSort))
             .map((t) => {
               const client = t.usuarios_turnos_codClienteTousuarios;
               const barber = t.usuarios_turnos_codBarberoTousuarios;

--- a/src/FRONT/views/components/Client/clientAppointments.tsx
+++ b/src/FRONT/views/components/Client/clientAppointments.tsx
@@ -4,14 +4,19 @@ import barberStyles from "../Client/clientAppointments.module.css";
 import toast from "react-hot-toast";
 import { useNavigate } from "react-router-dom";
 import type { AppointmentFull } from "../shared/appointments";
-import { formatDate, formatTime } from "../shared/appointments";
+import {
+  formatDate,
+  formatTime,
+  sortTurnosByDateTime,
+  unwrapAppointments,
+} from "../shared/appointments";
 import { apiFetch } from "../../lib/apiFetch.ts";
 
 const ClientAppointments: React.FC = () => {
   const { user, isAuthenticated } = useAuth();
   const [turnos, setTurnos] = useState<AppointmentFull[]>([]);
   const [statusFilter, setStatusFilter] = useState<string>("Todos");
-  const [dateSort, setDateSort] = useState<string>("asc");
+  const [dateSort, setDateSort] = useState<"asc" | "desc">("asc");
   const [authChecked, setAuthChecked] = useState(false);
   const navigate = useNavigate();
 
@@ -70,14 +75,7 @@ const ClientAppointments: React.FC = () => {
       })
       .then((data) => {
         console.log("Turnos data:", data);
-        // El backend devuelve { success: true, data: [...] }
-        let turnosArray: AppointmentFull[] = [];
-
-        if (data.success && Array.isArray(data.data)) {
-          turnosArray = data.data;
-        } else if (Array.isArray(data)) {
-          turnosArray = data;
-        }
+        const turnosArray = unwrapAppointments<AppointmentFull>(data);
 
         console.log("Turnos array procesado:", turnosArray);
         setTurnos(turnosArray);
@@ -189,7 +187,9 @@ const ClientAppointments: React.FC = () => {
         <select
           className={barberStyles.filterSelect}
           value={dateSort}
-          onChange={(e) => setDateSort(e.target.value)}
+          onChange={(e) =>
+            setDateSort(e.target.value as "asc" | "desc")
+          }
         >
           <option value="desc">Lejanos primero</option>
           <option value="asc">Próximos primero</option>
@@ -205,13 +205,7 @@ const ClientAppointments: React.FC = () => {
             .filter(
               (t) => statusFilter === "Todos" || t.estado === statusFilter,
             )
-            .sort((a, b) => {
-              const strA = `${a.fechaTurno.split("T")[0]}T${formatTime(a.horaDesde)}`;
-              const strB = `${b.fechaTurno.split("T")[0]}T${formatTime(b.horaDesde)}`;
-              return dateSort === "desc"
-                ? strB.localeCompare(strA)
-                : strA.localeCompare(strB);
-            })
+            .sort((a, b) => sortTurnosByDateTime(a, b, dateSort))
             .map((t) => {
               const barber = t.usuarios_turnos_codBarberoTousuarios;
               const branch = barber?.sucursales;

--- a/src/FRONT/views/components/Client/home/home.tsx
+++ b/src/FRONT/views/components/Client/home/home.tsx
@@ -9,6 +9,10 @@ import {
   useAbortController,
 } from "../../shared/useAbortController";
 import { apiFetch } from "../../../lib/apiFetch";
+import {
+  getTurnoDateTime,
+  unwrapAppointments,
+} from "../../shared/appointments";
 
 interface AppointmentSummary {
   codTurno: string;
@@ -226,10 +230,7 @@ const Home = () => {
         const now = new Date();
         const upcoming = turnosArray
           .map((turno) => {
-            const dateTime = buildTurnoDateTime(
-              turno.fechaTurno,
-              turno.horaDesde,
-            );
+            const dateTime = getTurnoDateTime(turno);
             return dateTime ? { turno, dateTime } : null;
           })
           .filter(
@@ -247,21 +248,13 @@ const Home = () => {
         console.error("Error fetching next appointment:", error);
         setNextTurno(null);
       })
-      .finally(() => {
-        setLoadingNextTurno(false);
-        setHasCheckedNextTurno(true);
-      });
-
-    return abortNextTurnoAbort;
-  }, [user?.codUsuario, renewNextTurnoAbort, abortNextTurnoAbort]);
+          .then((data) => {
+            const turnosArray = unwrapAppointments<AppointmentSummary>(data);
 
   useEffect(() => {
     if (!user?.codUsuario) return;
 
-    const controller = renewLoyaltyAbort();
-    setLoadingLoyalty(true);
-
-    apiFetch(`/usuarios/profiles/${user.codUsuario}`, {
+                const dateTime = getTurnoDateTime(turno);
       signal: controller.signal,
     })
       .then(async (res) => {

--- a/src/FRONT/views/components/shared/appointments.ts
+++ b/src/FRONT/views/components/shared/appointments.ts
@@ -37,6 +37,58 @@ export interface AppointmentFull {
   } | null;
 }
 
+
+export interface AppointmentDateLike {
+  fechaTurno: string;
+  horaDesde: string;
+}
+
+export const unwrapAppointments = <T>(data: unknown): T[] => {
+  if (Array.isArray(data)) return data as T[];
+  if (data && typeof data === "object" && "data" in data) {
+    const nested = (data as { data?: unknown }).data;
+    if (Array.isArray(nested)) return nested as T[];
+  }
+  return [];
+};
+
+export const buildTurnoDateTime = (
+  fechaTurno: string,
+  horaDesde: string,
+): Date | null => {
+  const datePart = fechaTurno.split("T")[0];
+  const [year, month, day] = datePart.split("-").map((value) => Number(value));
+  const startTime = new Date(horaDesde);
+
+  if (!year || !month || !day || Number.isNaN(startTime.getTime())) {
+    return null;
+  }
+
+  const hours = startTime.getUTCHours();
+  const minutes = startTime.getUTCMinutes();
+  return new Date(year, month - 1, day, hours, minutes, 0, 0);
+};
+
+export const getTurnoDateTime = (
+  turno: AppointmentDateLike,
+): Date | null => buildTurnoDateTime(turno.fechaTurno, turno.horaDesde);
+
+export const sortTurnosByDateTime = <T extends AppointmentDateLike>(
+  left: T,
+  right: T,
+  direction: "asc" | "desc" = "asc",
+): number => {
+  const leftDate = buildTurnoDateTime(left.fechaTurno, left.horaDesde);
+  const rightDate = buildTurnoDateTime(right.fechaTurno, right.horaDesde);
+
+  if (!leftDate && !rightDate) return 0;
+  if (!leftDate) return direction === "asc" ? 1 : -1;
+  if (!rightDate) return direction === "asc" ? -1 : 1;
+
+  return direction === "asc"
+    ? leftDate.getTime() - rightDate.getTime()
+    : rightDate.getTime() - leftDate.getTime();
+};
 export const formatDate = (dateString: string): string => {
   const [year, month, day] = dateString.split("T")[0].split("-");
   return `${day}/${month}/${year}`;

--- a/src/FRONT/views/pages/Barber/HomePageBarber.tsx
+++ b/src/FRONT/views/pages/Barber/HomePageBarber.tsx
@@ -8,6 +8,10 @@ import {
   useAbortController,
 } from "../../components/shared/useAbortController.ts";
 import { apiFetch } from "../../lib/apiFetch";
+import {
+  getTurnoDateTime,
+  unwrapAppointments,
+} from "../../components/shared/appointments";
 
 interface AppointmentPartial {
   codTurno: string;
@@ -90,33 +94,13 @@ const Home = () => {
         return res.json();
       })
       .then((data) => {
-        let turnosArray: AppointmentPartial[] = [];
-
-        if (data && data.success && Array.isArray(data.data)) {
-          turnosArray = data.data;
-        } else if (Array.isArray(data)) {
-          turnosArray = data;
-        }
+        const turnosArray = unwrapAppointments<AppointmentPartial>(data);
 
         const now = new Date();
         const upcoming = turnosArray
           .map((turno) => {
-            const datePart = turno.fechaTurno.split("T")[0];
-            const [year, month, day] = datePart
-              .split("-")
-              .map((value) => Number(value));
-            const startTime = new Date(turno.horaDesde);
-
-            if (!year || !month || !day || Number.isNaN(startTime.getTime())) {
-              return null;
-            }
-
-            const hours = startTime.getUTCHours();
-            const minutes = startTime.getUTCMinutes();
-            return {
-              turno,
-              dateTime: new Date(year, month - 1, day, hours, minutes, 0, 0),
-            };
+            const dateTime = getTurnoDateTime(turno);
+            return dateTime ? { turno, dateTime } : null;
           })
           .filter(
             (item): item is { turno: AppointmentPartial; dateTime: Date } =>


### PR DESCRIPTION
Se introducen helpers compartidos para turnos y se reemplaza la lógica duplicada de parsing y ordenamiento en los componentes.
Se agregó unwrapAppointments para normalizar las respuestas del backend y buildTurnoDateTime / getTurnoDateTime para construir objetos Date de forma consistente a partir de fechaTurno + horaDesde. También se añadió sortTurnosByDateTime y la interfaz AppointmentDateLike.
Se actualizaron los componentes de turnos de Barber y Client, junto con sus páginas relacionadas, para usar estas utilidades; se tipó de forma más estricta dateSort a la unión 'asc'|'desc', se eliminó el parsing de fechas en línea repetido y se agregaron casts seguros en los select change handlers.