### PR TITLE
Centralizar colores, espaciados y tamaños en tokens.css

### DIFF
--- a/src/FRONT/views/App.css
+++ b/src/FRONT/views/App.css
@@ -34,42 +34,6 @@ body {
   padding-bottom: 5rem;
 }
 
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
-}
-
-@keyframes logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
-  }
-}
-
-.card {
-  padding: 2em;
-}
-
-.read-the-docs {
-  color: #888;
-}
-
 
 /* MOBILE FIRSTs */
 [data-sonner-toaster] {
@@ -82,7 +46,7 @@ body {
   padding: 12px 16px !important;
   margin: 0 15px !important;
   border-radius: 12px !important;
-  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.15) !important;
+  box-shadow: 0 10px 40px var(--shadow-lg) !important;
   text-align: center !important;
 }
 [data-sonner-toast] button {

--- a/src/FRONT/views/App.tsx
+++ b/src/FRONT/views/App.tsx
@@ -231,8 +231,8 @@ function App() {
             toastOptions={{
               duration: 4000,
               style: {
-                background: "#363636",
-                color: "#fff",
+                background: "var(--color-gray-20)",
+                color: "var(--color-white)",
                 fontSize: "18px",
                 fontWeight: "500",
                 padding: "20px 30px",
@@ -244,13 +244,13 @@ function App() {
               success: {
                 duration: 2000,
                 style: {
-                  background: "#38a169",
+                  background: "var(--color-success)",
                 },
               },
               error: {
                 duration: 1500,
                 style: {
-                  background: "#e53e3e",
+                  background: "var(--color-danger-bright)",
                 },
               },
             }}

--- a/src/FRONT/views/components/Admin/barbers/barbers.module.css
+++ b/src/FRONT/views/components/Admin/barbers/barbers.module.css
@@ -3,8 +3,8 @@
 /* General Body and Root Styling */
 body {
   font-family: "Inter", sans-serif;
-  background-color: #f8f8f8;
-  color: #333;
+  background-color: var(--color-surface-light-18);
+  color: var(--color-gray-600);
   margin: 0;
   padding: 10px;
   line-height: 1.6;
@@ -16,9 +16,9 @@ body {
 .pageTitle,
 h2 {
   font-size: 2rem;
-  color: #1a202c;
+  color: var(--color-gray-950);
   text-align: center;
-  margin-bottom: 20px;
+  margin-bottom: var(--space-5);
   font-weight: 700;
   letter-spacing: -0.025em;
 }
@@ -26,18 +26,18 @@ h2 {
 .sectionTitle {
   font-size: 1.2rem;
   font-weight: 700;
-  color: #2d3748;
-  margin-bottom: 4px;
+  color: var(--color-gray-700);
+  margin-bottom: var(--space-1);
 }
 
 /* Container for IndexBarberos */
 .indexBarberos {
   max-width: 100%;
-  margin: 20px 0;
+  margin: var(--space-5) 0;
   padding: 15px;
-  background-color: #ffffff;
-  border-radius: 12px;
-  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.08);
+  background-color: var(--color-white);
+  border-radius: var(--radius-md);
+  box-shadow: 0 10px 25px var(--shadow-sm);
   animation: fadeIn 0.5s ease-out;
 }
 
@@ -48,16 +48,16 @@ h2 {
 }
 
 .indexBarberos li {
-  background-color: #f0f4f8;
-  border: 1px solid #e2e8f0;
+  background-color: var(--color-surface-light-1);
+  border: 1px solid var(--color-gray-100);
   border-radius: 8px;
-  padding: 16px;
-  margin-bottom: 12px;
+  padding: var(--space-4);
+  margin-bottom: var(--space-3);
   display: flex;
   flex-direction: row; /* layout like branches: info at left, actions at right */
   justify-content: space-between;
   align-items: flex-start;
-  gap: 16px;
+  gap: var(--space-4);
   transition:
     transform 0.2s ease,
     box-shadow 0.2s ease;
@@ -65,27 +65,27 @@ h2 {
 
 .indexBarberos li:hover {
   transform: translateY(-3px);
-  box-shadow: 0 6px 15px rgba(0, 0, 0, 0.05);
+  box-shadow: 0 6px 15px rgba(var(--shadow-color), 0.05);
 }
 
 .indexBarberos li strong {
   font-size: 1.1rem;
-  color: #2d3748;
+  color: var(--color-gray-700);
 }
 
 .indexBarberos li p {
   margin: 0;
-  color: #4a5568;
+  color: var(--color-gray-450);
 }
 
 /* Form Styles (for Create and Update) */
 .formContainer {
   max-width: 100%;
-  margin: 20px auto;
+  margin: var(--space-5) auto;
   padding: 15px;
-  background-color: #ffffff;
-  border-radius: 12px;
-  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.08);
+  background-color: var(--color-white);
+  border-radius: var(--radius-md);
+  box-shadow: 0 10px 25px var(--shadow-sm);
   animation: fadeIn 0.5s ease-out;
 }
 
@@ -97,46 +97,46 @@ h2 {
   display: block;
   margin-bottom: 6px;
   font-weight: 600;
-  color: #4a5568;
+  color: var(--color-gray-450);
   font-size: 0.95rem;
 }
 
 .formInput {
   width: 100%;
-  padding: 10px 12px;
-  border: 2px solid #a0aec0;
+  padding: 10px var(--space-3);
+  border: 2px solid var(--color-gray-125);
   border-radius: 8px;
   font-size: 0.95rem;
-  color: #2d3748;
+  color: var(--color-gray-700);
   transition:
     border-color 0.3s ease,
     box-shadow 0.3s ease;
   box-sizing: border-box;
-  box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.1);
+  box-shadow: inset 0 1px 3px var(--shadow-md);
 }
 
 .formInput:focus,
 .formSelect:focus {
   outline: none;
-  border-color: #4299e1;
-  box-shadow: 0 0 0 4px rgba(66, 153, 225, 0.6);
-  background-color: #e6f4ff;
+  border-color: var(--color-primary-hover);
+  box-shadow: 0 0 0 4px rgba(var(--color-primary-hover-rgb), 0.6);
+  background-color: var(--color-surface-light-4);
 }
 
 /* Select styles */
 .formSelect {
   width: 100%;
-  padding: 10px 12px;
-  border: 2px solid #a0aec0;
+  padding: 10px var(--space-3);
+  border: 2px solid var(--color-gray-125);
   border-radius: 8px;
   font-size: 0.95rem;
-  color: #2d3748;
+  color: var(--color-gray-700);
   transition:
     border-color 0.3s ease,
     box-shadow 0.3s ease;
   box-sizing: border-box;
-  box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.1);
-  background-color: #ffffff;
+  box-shadow: inset 0 1px 3px var(--shadow-md);
+  background-color: var(--color-white);
 }
 
 /* Buttons */
@@ -160,50 +160,50 @@ h2 {
 }
 .createButton {
   width: 100%;
-  margin: 0 auto 12px;
+  margin: 0 auto var(--space-3);
 }
 
 .createButtonWrapper {
   display: flex;
   justify-content: center;
   align-items: center;
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 .buttonPrimary {
-  background-color: #2b6cb0;
-  color: #ffffff;
-  box-shadow: 0 6px 15px rgba(43, 108, 176, 0.4);
+  background-color: var(--color-primary);
+  color: var(--color-white);
+  box-shadow: 0 6px 15px rgba(var(--color-primary-rgb), 0.4);
 }
 
 .buttonPrimary:hover {
-  background-color: #2c5282;
+  background-color: var(--color-blue-dark);
   transform: translateY(-3px);
-  box-shadow: 0 8px 20px rgba(43, 108, 176, 0.5);
+  box-shadow: 0 8px 20px rgba(var(--color-primary-rgb), 0.5);
 }
 
 .buttonDanger {
-  background-color: #c53030;
-  color: #ffffff;
-  box-shadow: 0 6px 15px rgba(197, 48, 48, 0.4);
+  background-color: var(--color-danger);
+  color: var(--color-white);
+  box-shadow: 0 6px 15px rgba(var(--color-danger-rgb), 0.4);
 }
 
 .buttonDanger:hover {
-  background-color: #9b2c2c;
+  background-color: var(--color-danger-mid);
   transform: translateY(-3px);
-  box-shadow: 0 8px 20px rgba(197, 48, 48, 0.5);
+  box-shadow: 0 8px 20px rgba(var(--color-danger-rgb), 0.5);
 }
 
 .buttonSuccess {
-  background-color: #38a169;
-  color: #ffffff;
-  box-shadow: 0 6px 15px rgba(56, 161, 105, 0.4);
+  background-color: var(--color-success);
+  color: var(--color-white);
+  box-shadow: 0 6px 15px rgba(var(--color-success-rgb), 0.4);
 }
 
 .buttonSuccess:hover {
-  background-color: #2f855a;
+  background-color: var(--color-success-mid);
   transform: translateY(-3px);
-  box-shadow: 0 8px 20px rgba(56, 161, 105, 0.5);
+  box-shadow: 0 8px 20px rgba(var(--color-success-rgb), 0.5);
 }
 
 .indexBarberos li .button {
@@ -214,7 +214,7 @@ h2 {
 
 .actionButtons {
   display: flex;
-  gap: 8px;
+  gap: var(--space-2);
   flex-wrap: wrap;
   align-items: flex-end;
   justify-content: flex-start;
@@ -224,7 +224,7 @@ h2 {
 
 .buttonGroup {
   display: flex;
-  gap: 8px;
+  gap: var(--space-2);
   flex-wrap: wrap;
   justify-content: flex-end;
   margin-top: 10px;
@@ -237,7 +237,7 @@ h2 {
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  margin-top: 16px;
+  margin-top: var(--space-4);
 }
 
 /* Barber info */
@@ -245,7 +245,7 @@ h2 {
   flex: 1;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .inactiveRow {
@@ -255,22 +255,22 @@ h2 {
 .barberoTitle {
   font-size: 1.2rem;
   font-weight: 700;
-  color: #2d3748;
-  margin-bottom: 4px;
+  color: var(--color-gray-700);
+  margin-bottom: var(--space-1);
 }
 
 .statusRow {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .statusBadge {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 4px 10px;
-  border-radius: 999px;
+  padding: var(--space-1) 10px;
+  border-radius: var(--radius-full);
   font-size: 0.8rem;
   font-weight: 700;
   letter-spacing: 0.02em;
@@ -278,18 +278,18 @@ h2 {
 }
 
 .statusActive {
-  background-color: #c6f6d5;
-  color: #22543d;
+  background-color: var(--color-success-bg);
+  color: var(--color-success-dark);
 }
 
 .statusInactive {
-  background-color: #fed7d7;
-  color: #742a2a;
+  background-color: var(--color-danger-bg);
+  color: var(--color-danger-dark);
 }
 
 .barberoDetails {
   font-size: 0.9rem;
-  color: #718096;
+  color: var(--color-gray-400);
   font-weight: 500;
 }
 
@@ -297,37 +297,37 @@ h2 {
 .barberoContacto,
 .barberoCode {
   font-size: 0.95rem;
-  color: #4a5568;
+  color: var(--color-gray-450);
 }
 
 .barberoDisponibilidad {
-  color: #4a5568;
+  color: var(--color-gray-450);
   line-height: 1.5;
-  margin-top: 4px;
+  margin-top: var(--space-1);
 }
 
 .barberoDisponible {
-  color: #38a169;
+  color: var(--color-success);
   font-weight: 600;
 }
 
 .barberoNoDisponible {
-  color: #e53e3e;
+  color: var(--color-danger-bright);
   font-weight: 600;
 }
 
 /* Loading and empty states */
 .loadingState {
   text-align: center;
-  padding: 30px;
-  color: #718096;
+  padding: var(--space-7);
+  color: var(--color-gray-400);
   font-size: 1rem;
 }
 
 .emptyState {
   text-align: center;
-  padding: 30px;
-  color: #718096;
+  padding: var(--space-7);
+  color: var(--color-gray-400);
 }
 
 .emptyState p {
@@ -337,22 +337,22 @@ h2 {
 
 /* Success message styling */
 .successMessage {
-  background-color: #c6f6d5;
-  color: #22543d;
-  padding: 10px 12px;
+  background-color: var(--color-success-bg);
+  color: var(--color-success-dark);
+  padding: 10px var(--space-3);
   border-radius: 8px;
   margin-bottom: 15px;
-  border-left: 4px solid #38a169;
+  border-left: 4px solid var(--color-success);
 }
 
 /* Error message styling */
 .errorMessage {
-  background-color: #fed7d7;
-  color: #742a2a;
-  padding: 10px 12px;
+  background-color: var(--color-danger-bg);
+  color: var(--color-danger-dark);
+  padding: 10px var(--space-3);
   border-radius: 8px;
   margin-bottom: 15px;
-  border-left: 4px solid #e53e3e;
+  border-left: 4px solid var(--color-danger-bright);
 }
 
 /* Animations */
@@ -371,76 +371,76 @@ h2 {
 .checkboxGroup {
   display: flex;
   flex-direction: column;
-  gap: 12px;
-  padding: 16px;
-  border: 1px solid #e2e8f0;
+  gap: var(--space-3);
+  padding: var(--space-4);
+  border: 1px solid var(--color-gray-100);
   border-radius: 8px;
-  background-color: #f8fafc;
+  background-color: var(--color-gray-25);
 }
 
 .checkboxItem {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .checkbox {
   width: 18px;
   height: 18px;
   cursor: pointer;
-  accent-color: #3b82f6;
+  accent-color: var(--color-blue-bright-3);
 }
 
 .checkboxLabel {
   cursor: pointer;
-  font-size: 14px;
-  color: #374151;
+  font-size: var(--font-size-sm);
+  color: var(--color-gray-750);
   user-select: none;
 }
 
 .checkboxLabel:hover {
-  color: #1f2937;
+  color: var(--color-gray-800);
 }
 
 .errorMessage {
-  color: #ef4444;
-  font-size: 12px;
-  margin-top: 4px;
+  color: var(--color-danger-alt-2);
+  font-size: var(--font-size-xs);
+  margin-top: var(--space-1);
 }
 
 /* Radio button styles */
 .radioGroup {
   display: flex;
   flex-direction: column;
-  gap: 12px;
-  padding: 16px;
-  border: 1px solid #e2e8f0;
+  gap: var(--space-3);
+  padding: var(--space-4);
+  border: 1px solid var(--color-gray-100);
   border-radius: 8px;
-  background-color: #f8fafc;
+  background-color: var(--color-gray-25);
 }
 
 .radioItem {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .radio {
   width: 18px;
   height: 18px;
   cursor: pointer;
-  accent-color: #3b82f6;
+  accent-color: var(--color-blue-bright-3);
 }
 
 .radioLabel {
   cursor: pointer;
-  font-size: 14px;
-  color: #374151;
+  font-size: var(--font-size-sm);
+  color: var(--color-gray-750);
   user-select: none;
 }
 
 .radioLabel:hover {
-  color: #1f2937;
+  color: var(--color-gray-800);
 }
 
 /* DESKTOP */
@@ -448,16 +448,16 @@ h2 {
   .pageTitle,
   h2 {
     font-size: 2.5rem;
-    margin-bottom: 30px;
+    margin-bottom: var(--space-7);
   }
   .indexBarberos,
   .formContainer {
     max-width: 800px;
-    margin: 40px auto;
-    padding: 30px;
+    margin: var(--space-8) auto;
+    padding: var(--space-7);
   }
   .indexBarberos li {
-    padding: 20px;
+    padding: var(--space-5);
     gap: 10px;
     margin-bottom: 15px;
   }
@@ -490,17 +490,17 @@ h2 {
   }
   .loadingState,
   .emptyState {
-    padding: 40px;
+    padding: var(--space-8);
     font-size: 1.1rem;
   }
   .emptyState p {
     font-size: 1.1rem;
-    margin-bottom: 20px;
+    margin-bottom: var(--space-5);
   }
   .successMessage,
   .errorMessage {
-    padding: 12px 16px;
-    margin-bottom: 20px;
+    padding: var(--space-3) var(--space-4);
+    margin-bottom: var(--space-5);
   }
   .sectionTitle {
     font-size: 1.35em;
@@ -512,7 +512,7 @@ h2 {
   .indexBarberos li {
     flex-direction: column;
     align-items: flex-start;
-    gap: 12px;
+    gap: var(--space-3);
   }
 
   .actionButtons {

--- a/src/FRONT/views/components/Admin/branches/branches.module.css
+++ b/src/FRONT/views/components/Admin/branches/branches.module.css
@@ -3,8 +3,8 @@
 /* General Body and Root Styling */
 body {
   font-family: "Inter", sans-serif;
-  background-color: #f8f8f8;
-  color: #333;
+  background-color: var(--color-surface-light-18);
+  color: var(--color-gray-600);
   margin: 0;
   padding: 10px;
   line-height: 1.6;
@@ -15,9 +15,9 @@ body {
 /* headings */
 h2 {
   font-size: 2rem;
-  color: #1a202c;
+  color: var(--color-gray-950);
   text-align: center;
-  margin-bottom: 20px;
+  margin-bottom: var(--space-5);
   font-weight: 700;
   letter-spacing: -0.025em;
 }
@@ -25,11 +25,11 @@ h2 {
 /* IndexSucursales container */
 .indexSucursales {
   max-width: 100%;
-  margin: 20px auto;
+  margin: var(--space-5) auto;
   padding: 15px;
-  background-color: #ffffff;
-  border-radius: 12px;
-  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.08);
+  background-color: var(--color-white);
+  border-radius: var(--radius-md);
+  box-shadow: 0 10px 25px var(--shadow-sm);
   animation: fadeIn 0.5s ease-out;
 }
 
@@ -40,42 +40,42 @@ h2 {
 }
 
 .indexSucursales li {
-  background-color: #f0f4f8;
-  border: 1px solid #e2e8f0;
+  background-color: var(--color-surface-light-1);
+  border: 1px solid var(--color-gray-100);
   border-radius: 8px;
-  padding: 16px;
-  margin-bottom: 12px;
+  padding: var(--space-4);
+  margin-bottom: var(--space-3);
   display: flex;
   flex-direction: row;
   justify-content: space-between;
   align-items: center;
-  gap: 16px;
+  gap: var(--space-4);
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
 .indexSucursales li:hover {
   transform: translateY(-3px);
-  box-shadow: 0 6px 15px rgba(0, 0, 0, 0.05);
+  box-shadow: 0 6px 15px rgba(var(--shadow-color), 0.05);
 }
 
 .indexSucursales li strong {
   font-size: 1.1rem;
-  color: #2d3748;
+  color: var(--color-gray-700);
 }
 
 .indexSucursales li p {
   margin: 0;
-  color: #4a5568;
+  color: var(--color-gray-450);
 }
 
 /* Form (create and update) */
 .formContainer {
   max-width: 100%;
-  margin: 20px 0;
+  margin: var(--space-5) 0;
   padding: 15px;
-  background-color: #ffffff;
-  border-radius: 12px;
-  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.08);
+  background-color: var(--color-white);
+  border-radius: var(--radius-md);
+  box-shadow: 0 10px 25px var(--shadow-sm);
   animation: fadeIn 0.5s ease-out;
 }
 
@@ -87,48 +87,48 @@ h2 {
   display: block;
   margin-bottom: 6px;
   font-weight: 600;
-  color: #4a5568;
+  color: var(--color-gray-450);
   font-size: 0.95rem;
 }
 
 .formInput {
   width: 100%;
-  padding: 10px 12px;
-  border: 2px solid #a0aec0;
+  padding: 10px var(--space-3);
+  border: 2px solid var(--color-gray-125);
   border-radius: 8px;
   font-size: 0.95rem;
-  color: #2d3748;
+  color: var(--color-gray-700);
   transition: border-color 0.3s ease, box-shadow 0.3s ease;
   box-sizing: border-box;
-  box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.1);
+  box-shadow: inset 0 1px 3px var(--shadow-md);
 }
 
 .formInput:focus {
   outline: none;
-  border-color: #4299e1;
-  box-shadow: 0 0 0 4px rgba(66, 153, 225, 0.6);
-  background-color: #e6f4ff; 
+  border-color: var(--color-primary-hover);
+  box-shadow: 0 0 0 4px rgba(var(--color-primary-hover-rgb), 0.6);
+  background-color: var(--color-surface-light-4); 
 }
 
 /* Select styles (reusable) */
 .formSelect {
   width: 100%;
-  padding: 10px 12px;
-  border: 2px solid #a0aec0;
+  padding: 10px var(--space-3);
+  border: 2px solid var(--color-gray-125);
   border-radius: 8px;
   font-size: 0.95rem;
-  color: #2d3748;
+  color: var(--color-gray-700);
   transition: border-color 0.3s ease, box-shadow 0.3s ease;
   box-sizing: border-box;
-  box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.1);
-  background-color: #ffffff;
+  box-shadow: inset 0 1px 3px var(--shadow-md);
+  background-color: var(--color-white);
 }
 
 .formSelect:focus {
   outline: none;
-  border-color: #4299e1;
-  box-shadow: 0 0 0 4px rgba(66, 153, 225, 0.6);
-  background-color: #e6f4ff;
+  border-color: var(--color-primary-hover);
+  box-shadow: 0 0 0 4px rgba(var(--color-primary-hover-rgb), 0.6);
+  background-color: var(--color-surface-light-4);
 }
 
 /* Buttons */
@@ -151,50 +151,50 @@ h2 {
 
 .createButton {
   width: 100%;
-  margin: 0 auto 12px;
+  margin: 0 auto var(--space-3);
 }
 
 .createButtonWrapper {
   display: flex;
   justify-content: center;
   align-items: center;
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 .buttonPrimary {
-  background-color: #2b6cb0;
-  color: #ffffff;
-  box-shadow: 0 6px 15px rgba(43, 108, 176, 0.4);
+  background-color: var(--color-primary);
+  color: var(--color-white);
+  box-shadow: 0 6px 15px rgba(var(--color-primary-rgb), 0.4);
 }
 
 .buttonPrimary:hover {
-  background-color: #2c5282;
+  background-color: var(--color-blue-dark);
   transform: translateY(-3px);
-  box-shadow: 0 8px 20px rgba(43, 108, 176, 0.5);
+  box-shadow: 0 8px 20px rgba(var(--color-primary-rgb), 0.5);
 }
 
 .buttonDanger {
-  background-color: #c53030;
-  color: #ffffff;
-  box-shadow: 0 6px 15px rgba(197, 48, 48, 0.4);
+  background-color: var(--color-danger);
+  color: var(--color-white);
+  box-shadow: 0 6px 15px rgba(var(--color-danger-rgb), 0.4);
 }
 
 .buttonDanger:hover {
-  background-color: #9b2c2c;
+  background-color: var(--color-danger-mid);
   transform: translateY(-3px);
-  box-shadow: 0 8px 20px rgba(197, 48, 48, 0.5);
+  box-shadow: 0 8px 20px rgba(var(--color-danger-rgb), 0.5);
 }
 
 .buttonSuccess {
-  background-color: #38a169;
-  color: #ffffff;
-  box-shadow: 0 6px 15px rgba(56, 161, 105, 0.4);
+  background-color: var(--color-success);
+  color: var(--color-white);
+  box-shadow: 0 6px 15px rgba(var(--color-success-rgb), 0.4);
 }
 
 .buttonSuccess:hover {
-  background-color: #2f855a;
+  background-color: var(--color-success-mid);
   transform: translateY(-3px);
-  box-shadow: 0 8px 20px rgba(56, 161, 105, 0.5);
+  box-shadow: 0 8px 20px rgba(var(--color-success-rgb), 0.5);
 }
 
 .indexSucursales li .button {
@@ -219,18 +219,18 @@ h2 {
 @media (min-width: 769px) {
   h2 {
     font-size: 2.5rem;
-    margin-bottom: 30px;
+    margin-bottom: var(--space-7);
   }
 
   .indexSucursales,
   .formContainer {
     max-width: 800px;
-    margin: 40px auto;
-    padding: 30px;
+    margin: var(--space-8) auto;
+    padding: var(--space-7);
   }
 
   .indexSucursales li {
-    padding: 20px;
+    padding: var(--space-5);
     gap: 10px;
   }
 
@@ -254,7 +254,7 @@ h2 {
   flex-wrap: wrap;
   justify-content: center;
   align-items: center;
-  margin-top: 16px;
+  margin-top: var(--space-4);
 }
 
 /* branch info */
@@ -262,7 +262,7 @@ h2 {
   flex: 1;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .inactiveRow {
@@ -272,22 +272,22 @@ h2 {
 .sucursalTitle {
   font-size: 1.2rem;
   font-weight: 700;
-  color: #2d3748;
-  margin-bottom: 4px;
+  color: var(--color-gray-700);
+  margin-bottom: var(--space-1);
 }
 
 .statusRow {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .statusBadge {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 4px 10px;
-  border-radius: 999px;
+  padding: var(--space-1) 10px;
+  border-radius: var(--radius-full);
   font-size: 0.8rem;
   font-weight: 700;
   letter-spacing: 0.02em;
@@ -295,25 +295,25 @@ h2 {
 }
 
 .statusActive {
-  background-color: #c6f6d5;
-  color: #22543d;
+  background-color: var(--color-success-bg);
+  color: var(--color-success-dark);
 }
 
 .statusInactive {
-  background-color: #fed7d7;
-  color: #742a2a;
+  background-color: var(--color-danger-bg);
+  color: var(--color-danger-dark);
 }
 
 .sucursalCalle, .sucursalAltura {
   font-size: 0.9rem;
-  color: #404855;
+  color: var(--color-gray-650);
   font-weight: 500;
 }
 
 
 .actionButtons {
   display: flex;
-  gap: 8px;
+  gap: var(--space-2);
   flex-wrap: wrap;
   align-items: center;
   justify-content: flex-end;
@@ -322,28 +322,28 @@ h2 {
 
 .emptyState {
   text-align: center;
-  padding: 40px 20px;
-  color: #718096;
+  padding: var(--space-8) var(--space-5);
+  color: var(--color-gray-400);
   font-size: 1.1rem;
 }
 
 .loadingState {
   text-align: center;
-  padding: 40px 20px;
-  color: #718096;
+  padding: var(--space-8) var(--space-5);
+  color: var(--color-gray-400);
   font-size: 1.1rem;
   font-weight: 500;
 }
 
 /* Barbers: section and list of cards */
 .barberosSection {
-  margin-top: 24px;
+  margin-top: var(--space-6);
 }
 
 .barberosSection h2 {
   font-size: 1.25rem;
-  margin: 0 0 12px 0;
-  color: #1a202c;
+  margin: 0 0 var(--space-3) 0;
+  color: var(--color-gray-950);
   text-align: left;
 }
 
@@ -353,14 +353,14 @@ h2 {
   margin: 0;
   display: grid;
   grid-template-columns: 1fr;
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 .barberItem {
-  background: linear-gradient(180deg, #ffffff 0%, #fbfdff 100%);
-  border: 1px solid #e6edf3;
+  background: linear-gradient(180deg, var(--color-white) 0%, var(--color-surface-light-15) 100%);
+  border: 1px solid var(--color-surface-light-10);
   border-radius: 10px;
-  padding: 12px 14px;
+  padding: var(--space-3) 14px;
   display: flex;
   flex-direction: column;
   gap: 6px;
@@ -369,24 +369,24 @@ h2 {
 
 .barberItem:hover {
   transform: translateY(-4px);
-  box-shadow: 0 10px 24px rgba(17, 24, 39, 0.08);
+  box-shadow: 0 10px 24px rgba(var(--color-gray-900-rgb), 0.08);
 }
 
 .barberItem strong {
   font-size: 1rem;
-  color: #0f172a;
+  color: var(--color-accent-slate);
 }
 
 .barberItem div {
   font-size: 0.9rem;
-  color: #475569;
+  color: var(--color-gray-250);
 }
 
 /* Desktop grid: two columns*/
 @media (min-width: 700px) {
   .barberList {
     grid-template-columns: repeat(2, 1fr);
-    gap: 16px;
+    gap: var(--space-4);
   }
     .detailsActionButtons .button {
     width: 240px;
@@ -404,7 +404,7 @@ h2 {
   .indexSucursales li {
     flex-direction: column;
     align-items: flex-start;
-    gap: 12px;
+    gap: var(--space-3);
   }
 
   .actionButtons {
@@ -419,19 +419,19 @@ h2 {
 
 
 .successMessage {
-  background-color: #c6f6d5;
-  color: #22543d;
-  padding: 12px 16px;
+  background-color: var(--color-success-bg);
+  color: var(--color-success-dark);
+  padding: var(--space-3) var(--space-4);
   border-radius: 8px;
-  margin-bottom: 20px;
-  border-left: 4px solid #38a169;
+  margin-bottom: var(--space-5);
+  border-left: 4px solid var(--color-success);
 }
 
 .errorMessage {
-  background-color: #fed7d7;
-  color: #742a2a;
-  padding: 12px 16px;
+  background-color: var(--color-danger-bg);
+  color: var(--color-danger-dark);
+  padding: var(--space-3) var(--space-4);
   border-radius: 8px;
-  margin-bottom: 20px;
-  border-left: 4px solid #e53e3e;
+  margin-bottom: var(--space-5);
+  border-left: 4px solid var(--color-danger-bright);
 }

--- a/src/FRONT/views/components/Admin/categories/categories.module.css
+++ b/src/FRONT/views/components/Admin/categories/categories.module.css
@@ -3,10 +3,10 @@
 /* General Body and Root Styling */
 body {
   font-family: "Inter", sans-serif;
-  background-color: #f8f8f8;
-  color: #333;
+  background-color: var(--color-surface-light-18);
+  color: var(--color-gray-600);
   margin: 0;
-  padding: 12px;
+  padding: var(--space-3);
   line-height: 1.6;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -15,9 +15,9 @@ body {
 /* Headings */
 .pageTitle, h2 {
   font-size: 1.7rem;
-  color: #1a202c;
+  color: var(--color-gray-950);
   text-align: center;
-  margin-bottom: 16px;
+  margin-bottom: var(--space-4);
   font-weight: 700;
   letter-spacing: -0.025em;
 }
@@ -26,11 +26,11 @@ body {
 /* Container for IndexCategorias */
 .indexCategories {
   max-width: 100%;
-  margin: 16px auto;
+  margin: var(--space-4) auto;
   padding: 14px;
-  background-color: #ffffff;
-  border-radius: 12px;
-  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.08);
+  background-color: var(--color-white);
+  border-radius: var(--radius-md);
+  box-shadow: 0 10px 25px var(--shadow-sm);
   animation: fadeIn 0.5s ease-out;
 }
 
@@ -41,42 +41,42 @@ body {
 }
 
 .indexCategories li {
-  background-color: #f0f4f8;
-  border: 1px solid #e2e8f0;
+  background-color: var(--color-surface-light-1);
+  border: 1px solid var(--color-gray-100);
   border-radius: 8px;
-  padding: 16px;
-  margin-bottom: 12px;
+  padding: var(--space-4);
+  margin-bottom: var(--space-3);
   display: flex;
   flex-direction: row; /* info left, actions right — match branches */
   justify-content: space-between;
   align-items: center;
-  gap: 16px;
+  gap: var(--space-4);
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
 .indexCategories li:hover {
   transform: translateY(-3px);
-  box-shadow: 0 6px 15px rgba(0, 0, 0, 0.05);
+  box-shadow: 0 6px 15px rgba(var(--shadow-color), 0.05);
 }
 
 .indexCategories li strong {
   font-size: 1.1rem;
-  color: #2d3748;
+  color: var(--color-gray-700);
 }
 
 .indexCategories li p {
   margin: 0;
-  color: #4a5568;
+  color: var(--color-gray-450);
 }
 
 /* Form Styles (for Create and Modificar) */
 .formContainer {
   max-width: 100%;
-  margin: 16px auto;
+  margin: var(--space-4) auto;
   padding: 14px;
-  background-color: #ffffff;
-  border-radius: 12px;
-  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.08);
+  background-color: var(--color-white);
+  border-radius: var(--radius-md);
+  box-shadow: 0 10px 25px var(--shadow-sm);
   animation: fadeIn 0.5s ease-out;
 }
 
@@ -88,27 +88,27 @@ body {
   display: block;
   margin-bottom: 6px;
   font-weight: 600;
-  color: #4a5568;
+  color: var(--color-gray-450);
   font-size: 0.95rem;
 }
 
 .formInput, .formTextarea  {
   width: 100%;
-  padding: 10px 12px;
-  border: 2px solid #a0aec0;
+  padding: 10px var(--space-3);
+  border: 2px solid var(--color-gray-125);
   border-radius: 8px;
   font-size: 0.95rem;
-  color: #2d3748;
+  color: var(--color-gray-700);
   transition: border-color 0.3s ease, box-shadow 0.3s ease;
   box-sizing: border-box;
-  box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.1);
+  box-shadow: inset 0 1px 3px var(--shadow-md);
 }
 
 .formInput:focus, .formTextarea:focus  {
   outline: none;
-  border-color: #4299e1;
-  box-shadow: 0 0 0 4px rgba(66, 153, 225, 0.6);
-  background-color: #e6f4ff;
+  border-color: var(--color-primary-hover);
+  box-shadow: 0 0 0 4px rgba(var(--color-primary-hover-rgb), 0.6);
+  background-color: var(--color-surface-light-4);
 }
 
 .formTextarea {
@@ -137,39 +137,39 @@ body {
 
 .createButton {
   width: 100%;
-  margin: 0 auto 12px;
+  margin: 0 auto var(--space-3);
 }
 
 .createButtonWrapper {
   display: flex;
   justify-content: center;
   align-items: center;
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 .buttonPrimary {
-  background-color: #2b6cb0;
-  color: #ffffff;
-  box-shadow: 0 6px 15px rgba(43, 108, 176, 0.4);
+  background-color: var(--color-primary);
+  color: var(--color-white);
+  box-shadow: 0 6px 15px rgba(var(--color-primary-rgb), 0.4);
 }
 
 .buttonPrimary:hover {
-  background-color: #2c5282;
+  background-color: var(--color-blue-dark);
   transform: translateY(-3px);
-  box-shadow: 0 8px 20px rgba(43, 108, 176, 0.5);
+  box-shadow: 0 8px 20px rgba(var(--color-primary-rgb), 0.5);
 
 }
 
 .buttonDanger {
-  background-color: #c53030;
-  color: #ffffff;
-  box-shadow: 0 6px 15px rgba(197, 48, 48, 0.4);
+  background-color: var(--color-danger);
+  color: var(--color-white);
+  box-shadow: 0 6px 15px rgba(var(--color-danger-rgb), 0.4);
 }
 
 .buttonDanger:hover {
-  background-color: #9b2c2c;
+  background-color: var(--color-danger-mid);
   transform: translateY(-3px);
-  box-shadow: 0 8px 20px rgba(197, 48, 48, 0.5);
+  box-shadow: 0 8px 20px rgba(var(--color-danger-rgb), 0.5);
 }
 
 .buttonDisabled {
@@ -180,21 +180,21 @@ body {
 }
 
 .buttonDisabled:hover {
-  background-color: #c53030;
+  background-color: var(--color-danger);
   transform: none;
   box-shadow: none;
 }
 
 .buttonSuccess {
-  background-color: #38a169;
-  color: #ffffff;
-  box-shadow: 0 6px 15px rgba(56, 161, 105, 0.4);
+  background-color: var(--color-success);
+  color: var(--color-white);
+  box-shadow: 0 6px 15px rgba(var(--color-success-rgb), 0.4);
 }
 
 .buttonSuccess:hover {
-  background-color: #2f855a;
+  background-color: var(--color-success-mid);
   transform: translateY(-3px);
-  box-shadow: 0 8px 20px rgba(56, 161, 105, 0.5);
+  box-shadow: 0 8px 20px rgba(var(--color-success-rgb), 0.5);
 }
 
 
@@ -206,7 +206,7 @@ body {
 
 .actionButtons {
   display: flex;
-  gap: 8px;
+  gap: var(--space-2);
   flex-wrap: wrap;
   align-items: stretch;
   justify-content: stretch;
@@ -223,34 +223,34 @@ body {
 .categoryTitle {
   font-size: 1.2rem;
   font-weight: 700;
-  color: #2d3748;
-  margin-bottom: 4px;
+  color: var(--color-gray-700);
+  margin-bottom: var(--space-1);
 }
 
 .categoryCode {
   font-size: 0.9rem;
-  color: #718096;
+  color: var(--color-gray-400);
   font-weight: 500;
 }
 
 .categoryDescription {
-  color: #4a5568;
+  color: var(--color-gray-450);
   line-height: 1.5;
-  margin-top: 4px;
+  margin-top: var(--space-1);
 }
 
 /* Loading and empty states */
 .loadingState {
   text-align: center;
-  padding: 30px;
-  color: #718096;
+  padding: var(--space-7);
+  color: var(--color-gray-400);
   font-size: 1rem;
 }
 
 .emptyState {
   text-align: center;
-  padding: 30px;
-  color: #718096;
+  padding: var(--space-7);
+  color: var(--color-gray-400);
 }
 
 .emptyState p {
@@ -262,18 +262,18 @@ body {
 .modalOverlay {
   position: fixed;
   inset: 0;
-  background: rgba(15, 23, 42, 0.45);
+  background: rgba(var(--color-slate-rgb), 0.45);
   display: flex;
   align-items: center;
   justify-content: center;
   z-index: 50;
-  padding: 20px;
+  padding: var(--space-5);
 }
 
 .modalCard {
-  background: #ffffff;
+  background: var(--color-white);
   border-radius: 16px;
-  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.2);
+  box-shadow: 0 20px 40px rgba(var(--color-slate-rgb), 0.2);
   width: min(980px, 100%);
   max-height: 85vh;
   display: flex;
@@ -282,30 +282,30 @@ body {
 }
 
 .modalHeader {
-  padding: 20px 24px 12px;
-  border-bottom: 1px solid #e2e8f0;
+  padding: var(--space-5) var(--space-6) var(--space-3);
+  border-bottom: 1px solid var(--color-gray-100);
 }
 
 .modalHeader h3 {
   margin: 0 0 6px 0;
   font-size: 1.4rem;
-  color: #1a202c;
+  color: var(--color-gray-950);
 }
 
 .modalHeader p {
   margin: 0;
-  color: #4a5568;
+  color: var(--color-gray-450);
 }
 
 .modalBody {
-  padding: 16px 24px 20px;
+  padding: var(--space-4) var(--space-6) var(--space-5);
   overflow: auto;
 }
 
 .modalHint {
   font-size: 0.95rem;
-  color: #4a5568;
-  margin-bottom: 12px;
+  color: var(--color-gray-450);
+  margin-bottom: var(--space-3);
 }
 
 .modalTable {
@@ -317,47 +317,47 @@ body {
 .modalRowHeader {
   display: grid;
   grid-template-columns: 1.6fr 0.6fr 0.6fr 1fr;
-  gap: 12px;
+  gap: var(--space-3);
   font-weight: 600;
-  color: #2d3748;
+  color: var(--color-gray-700);
   font-size: 0.9rem;
 }
 
 .modalRow {
   display: grid;
   grid-template-columns: 1.6fr 0.6fr 0.6fr 1fr;
-  gap: 12px;
+  gap: var(--space-3);
   align-items: center;
-  padding: 12px 14px;
-  background: #f7fafc;
-  border-radius: 12px;
+  padding: var(--space-3) 14px;
+  background: var(--color-surface-light-21);
+  border-radius: var(--radius-md);
 }
 
 .modalName {
   font-weight: 600;
-  color: #1a202c;
+  color: var(--color-gray-950);
 }
 
 .modalMuted {
   font-size: 0.85rem;
-  color: #718096;
+  color: var(--color-gray-400);
 }
 
 .modalSelect {
   width: 100%;
-  padding: 8px 10px;
+  padding: var(--space-2) 10px;
   border-radius: 8px;
-  border: 1px solid #cbd5f5;
-  background: #ffffff;
+  border: 1px solid var(--color-surface-light-14);
+  background: var(--color-white);
   font-size: 0.9rem;
 }
 
 .modalFooter {
-  padding: 16px 24px 22px;
+  padding: var(--space-4) var(--space-6) 22px;
   display: flex;
-  gap: 12px;
+  gap: var(--space-3);
   justify-content: flex-end;
-  border-top: 1px solid #e2e8f0;
+  border-top: 1px solid var(--color-gray-100);
 }
 
 @media (max-width: 720px) {
@@ -375,19 +375,19 @@ body {
 .backButton {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
-  background-color: #e2e8f0;
-  color: #4a5568;
-  padding: 8px 14px;
+  gap: var(--space-2);
+  background-color: var(--color-gray-100);
+  color: var(--color-gray-450);
+  padding: var(--space-2) 14px;
   border-radius: 8px;
   text-decoration: none;
   font-weight: 500;
   transition: background-color 0.3s ease, transform 0.2s ease;
-  margin-bottom: 12px;
+  margin-bottom: var(--space-3);
 }
 
 .backButton:hover {
-  background-color: #cbd5e0;
+  background-color: var(--color-gray-150);
   transform: translateY(-2px);
 }
 
@@ -397,13 +397,13 @@ body {
   flex-wrap: wrap;
   justify-content: center;
   align-items: center;
-  margin-top: 16px;
+  margin-top: var(--space-4);
 }
 
 /* DESKTOP*/
 @media (min-width: 769px) {
   body {
-    padding: 24px;
+    padding: var(--space-6);
   }
   .pageTitle,
   h2 {
@@ -417,9 +417,9 @@ body {
     padding: 28px;
   }
   .indexCategories li {
-    padding: 20px 22px;
+    padding: var(--space-5) 22px;
     gap: 14px;
-    margin-bottom: 16px;
+    margin-bottom: var(--space-4);
   }
   .button {
     width: auto;
@@ -460,13 +460,13 @@ body {
     margin-bottom: 18px;
   }
   .backButton {
-    padding: 10px 20px;
+    padding: 10px var(--space-5);
     margin-bottom: 18px;
   }
   .successMessage,
   .errorMessage {
-    padding: 12px 16px;
-    margin-bottom: 20px;
+    padding: var(--space-3) var(--space-4);
+    margin-bottom: var(--space-5);
   }
   
 }
@@ -474,7 +474,7 @@ body {
   .indexCategories li {
     flex-direction: column;
     align-items: flex-start;
-    gap: 12px;
+    gap: var(--space-3);
   }
 
   .actionButtons {
@@ -502,20 +502,20 @@ body {
 
 /* Success message styling */
 .successMessage {
-  background-color: #c6f6d5;
-  color: #22543d;
-  padding: 10px 12px;
+  background-color: var(--color-success-bg);
+  color: var(--color-success-dark);
+  padding: 10px var(--space-3);
   border-radius: 8px;
   margin-bottom: 15px;
-  border-left: 4px solid #38a169;
+  border-left: 4px solid var(--color-success);
 }
 
 /* Error message styling */
 .errorMessage {
-  background-color: #fed7d7;
-  color: #742a2a;
-  padding: 10px 12px;
+  background-color: var(--color-danger-bg);
+  color: var(--color-danger-dark);
+  padding: 10px var(--space-3);
   border-radius: 8px;
   margin-bottom: 15px;
-  border-left: 4px solid #e53e3e;
+  border-left: 4px solid var(--color-danger-bright);
 }

--- a/src/FRONT/views/components/Admin/categories/indexCategories.tsx
+++ b/src/FRONT/views/components/Admin/categories/indexCategories.tsx
@@ -169,7 +169,7 @@ const IndexCategories = () => {
           >
             Esta categoría tiene {context.clientes.length} clientes.
           </p>
-          <p style={{ margin: "0 0 16px 0", color: "#4a5568" }}>
+          <p style={{ margin: "0 0 16px 0", color: "var(--color-gray-450)" }}>
             ¿Qué querés hacer con ellos?
           </p>
           <div
@@ -189,7 +189,7 @@ const IndexCategories = () => {
                   });
                 }}
                 style={{
-                  background: "#2f855a",
+                  background: "var(--color-success-mid)",
                   color: "white",
                   border: "none",
                   padding: "10px 16px",
@@ -211,7 +211,7 @@ const IndexCategories = () => {
                   });
                 }}
                 style={{
-                  background: "#b83280",
+                  background: "var(--color-accent-pink)",
                   color: "white",
                   border: "none",
                   padding: "10px 16px",
@@ -238,7 +238,7 @@ const IndexCategories = () => {
                 setDeleteContext(context);
               }}
               style={{
-                background: "#2b6cb0",
+                background: "var(--color-primary)",
                 color: "white",
                 border: "none",
                 padding: "10px 16px",
@@ -253,7 +253,7 @@ const IndexCategories = () => {
             <button
               onClick={() => toast.dismiss(t.id)}
               style={{
-                background: "#718096",
+                background: "var(--color-gray-400)",
                 color: "white",
                 border: "none",
                 padding: "10px 16px",

--- a/src/FRONT/views/components/Admin/clients/indexClients.module.css
+++ b/src/FRONT/views/components/Admin/clients/indexClients.module.css
@@ -5,16 +5,16 @@
 }
 
 .card {
-    background: #ffffff;
+    background: var(--color-white);
     border-radius: 0.5rem;
-    box-shadow: 0 6px 18px rgba(15, 23, 42, 0.06);
+    box-shadow: 0 6px 18px rgba(var(--color-slate-rgb), 0.06);
     padding: 0.75rem;
 }
 
 .title {
     font-size: 1.125rem;
     font-weight: 600;
-    color: #111827;
+    color: var(--color-gray-900);
     margin-bottom: 0.75rem;
 }
 
@@ -44,7 +44,7 @@
 }
 
 .filterLabel {
-    color: #374151;
+    color: var(--color-gray-750);
     font-weight: 600;
     font-size: 0.95rem;
 }
@@ -52,39 +52,39 @@
 .select {
     padding: 0.35rem 0.6rem;
     border-radius: 0.375rem;
-    border: 1px solid #e5e7eb;
-    background: white;
-    color: #111827;
+    border: 1px solid var(--color-gray-200);
+    background: var(--color-white);
+    color: var(--color-gray-900);
 }
 
 .countBadge {
-    background: #f3f4f6;
-    color: #374151;
+    background: var(--color-gray-50);
+    color: var(--color-gray-750);
     padding: 0.25rem 0.6rem;
-    border-radius: 999px;
+    border-radius: var(--radius-full);
     font-weight: 700;
     font-size: 0.9rem;
 }
 .table thead th {
     text-align: left;
     padding: 0.75rem;
-    background: #f9fafb;
-    color: #374151;
+    background: var(--color-surface-light-16);
+    color: var(--color-gray-750);
     font-weight: 600;
-    border-bottom: 1px solid #e5e7eb;
+    border-bottom: 1px solid var(--color-gray-200);
 }
 
 .table td {
     padding: 0.65rem 0.75rem;
-    border-bottom: 1px solid #eef2f6;
+    border-bottom: 1px solid var(--color-surface-light-5);
     vertical-align: middle;
-    color: #1f2937;
+    color: var(--color-gray-800);
 }
 
 .empty {
     text-align: center;
     padding: 1.25rem;
-    color: #6b7280;
+    color: var(--color-gray-300);
 }
 
 .actions {
@@ -103,12 +103,12 @@
 }
 
 .btnView {
-    background-color: #1f2937;
-    color: #fff;
+    background-color: var(--color-gray-800);
+    color: var(--color-white);
 }
 
 .smallMuted {
-    color: #6b7280;
+    color: var(--color-gray-300);
     font-size: 0.95rem;
 }
 
@@ -118,12 +118,12 @@
 
 .profileInner p {
     margin: 0.25rem 0;
-    color: #374151;
+    color: var(--color-gray-750);
 }
 
 .loading {
     padding: 1rem;
-    color: #6b7280;
+    color: var(--color-gray-300);
 }
 
 
@@ -134,8 +134,8 @@
 }
 
 .clientCard {
-    background: #ffffff;
-    border: 1px solid #eef2f6;
+    background: var(--color-white);
+    border: 1px solid var(--color-surface-light-5);
     border-radius: 0.5rem;
     padding: 0.75rem;
     margin-bottom: 0.75rem;
@@ -154,7 +154,7 @@
 
 .clientCard .smallMuted {
     font-size: 0.85rem;
-    color: #6b7280;
+    color: var(--color-gray-300);
 }
 
 .tableWrap {

--- a/src/FRONT/views/components/Admin/shared/confirmActionToast.tsx
+++ b/src/FRONT/views/components/Admin/shared/confirmActionToast.tsx
@@ -24,8 +24,8 @@ const CONFIRM_COLORS: Record<
   "danger" | "success",
   { base: string; hover: string }
 > = {
-  danger: { base: "#e53e3e", hover: "#c53030" },
-  success: { base: "#10b981", hover: "#059669" },
+  danger: { base: "var(--color-danger-bright)", hover: "var(--color-danger)" },
+  success: { base: "var(--color-success-alt-5)", hover: "var(--color-success-alt-4)" },
 };
 
 export const showConfirmActionToast = ({
@@ -74,12 +74,12 @@ export const showConfirmActionToast = ({
           </button>
           <button
             onClick={() => toast.dismiss(t.id)}
-            style={{ ...BASE_BUTTON_STYLE, background: "#718096" }}
+            style={{ ...BASE_BUTTON_STYLE, background: "var(--color-gray-400)" }}
             onMouseEnter={(e) => {
-              e.currentTarget.style.background = "#4a5568";
+              e.currentTarget.style.background = "var(--color-gray-450)";
             }}
             onMouseLeave={(e) => {
-              e.currentTarget.style.background = "#718096";
+              e.currentTarget.style.background = "var(--color-gray-400)";
             }}
           >
             {cancelLabel}

--- a/src/FRONT/views/components/Admin/typeOfHaircut/typeOfHaircut.module.css
+++ b/src/FRONT/views/components/Admin/typeOfHaircut/typeOfHaircut.module.css
@@ -3,8 +3,8 @@
 /* General Body and Root Styling */
 body {
   font-family: "Inter", sans-serif;
-  background-color: #f8f8f8;
-  color: #333;
+  background-color: var(--color-surface-light-18);
+  color: var(--color-gray-600);
   margin: 0;
   padding: 10px;
   line-height: 1.6;
@@ -15,9 +15,9 @@ body {
 /* headings */
 h2 {
   font-size: 2rem;
-  color: #1a202c;
+  color: var(--color-gray-950);
   text-align: center;
-  margin-bottom: 20px;
+  margin-bottom: var(--space-5);
   font-weight: 700;
   letter-spacing: -0.025em;
 }
@@ -26,11 +26,11 @@ h2 {
 /* container de IndexTipoCortes */
 .indexTipoCortes {
   max-width: 100%;
-  margin: 20px auto;
+  margin: var(--space-5) auto;
   padding: 15px;
-  background-color: #ffffff;
-  border-radius: 12px;
-  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.08);
+  background-color: var(--color-white);
+  border-radius: var(--radius-md);
+  box-shadow: 0 10px 25px var(--shadow-sm);
   animation: fadeIn 0.5s ease-out;
 }
 
@@ -41,42 +41,42 @@ h2 {
 }
 
 .indexTipoCortes li {
-  background-color: #f0f4f8;
-  border: 1px solid #e2e8f0;
+  background-color: var(--color-surface-light-1);
+  border: 1px solid var(--color-gray-100);
   border-radius: 8px;
-  padding: 16px;
-  margin-bottom: 12px;
+  padding: var(--space-4);
+  margin-bottom: var(--space-3);
   display: flex;
   flex-direction: row;
   justify-content: space-between;
   align-items: center;
-  gap: 16px;
+  gap: var(--space-4);
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
 .indexTipoCortes li:hover {
   transform: translateY(-3px);
-  box-shadow: 0 6px 15px rgba(0, 0, 0, 0.05);
+  box-shadow: 0 6px 15px rgba(var(--shadow-color), 0.05);
 }
 
 .indexTipoCortes li strong {
   font-size: 1.1rem;
-  color: #2d3748;
+  color: var(--color-gray-700);
 }
 
 .indexTipoCortes li p {
   margin: 0;
-  color: #4a5568;
+  color: var(--color-gray-450);
 }
 
 /* Form (create y modificar) */
 .formContainer {
   max-width: 100%;
-  margin: 20px 0;
+  margin: var(--space-5) 0;
   padding: 15px;
-  background-color: #ffffff;
-  border-radius: 12px;
-  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.08);
+  background-color: var(--color-white);
+  border-radius: var(--radius-md);
+  box-shadow: 0 10px 25px var(--shadow-sm);
   animation: fadeIn 0.5s ease-out;
 }
 
@@ -88,27 +88,27 @@ h2 {
   display: block;
   margin-bottom: 6px;
   font-weight: 600;
-  color: #4a5568;
+  color: var(--color-gray-450);
   font-size: 0.95rem;
 }
 
 .formInput {
   width: 100%;
-  padding: 10px 12px;
-  border: 2px solid #a0aec0;
+  padding: 10px var(--space-3);
+  border: 2px solid var(--color-gray-125);
   border-radius: 8px;
   font-size: 0.95rem;
-  color: #2d3748;
+  color: var(--color-gray-700);
   transition: border-color 0.3s ease, box-shadow 0.3s ease;
   box-sizing: border-box;
-  box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.1);
+  box-shadow: inset 0 1px 3px var(--shadow-md);
 }
 
 .formInput:focus {
   outline: none;
-  border-color: #4299e1; 
-  box-shadow: 0 0 0 4px rgba(66, 153, 225, 0.6);
-  background-color: #e6f4ff; 
+  border-color: var(--color-primary-hover); 
+  box-shadow: 0 0 0 4px rgba(var(--color-primary-hover-rgb), 0.6);
+  background-color: var(--color-surface-light-4); 
 }
 
 /* Buttons */
@@ -133,50 +133,50 @@ h2 {
 
 .createButton {
   width: 100%;
-  margin: 0 auto 12px;
+  margin: 0 auto var(--space-3);
 }
 
 .createButtonWrapper {
   display: flex;
   justify-content: center;
   align-items: center;
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 .buttonPrimary {
-  background-color: #2b6cb0;
-  color: #ffffff;
-  box-shadow: 0 6px 15px rgba(43, 108, 176, 0.4);
+  background-color: var(--color-primary);
+  color: var(--color-white);
+  box-shadow: 0 6px 15px rgba(var(--color-primary-rgb), 0.4);
 }
 
 .buttonPrimary:hover {
-  background-color: #2c5282;
+  background-color: var(--color-blue-dark);
   transform: translateY(-3px);
-  box-shadow: 0 8px 20px rgba(43, 108, 176, 0.5);
+  box-shadow: 0 8px 20px rgba(var(--color-primary-rgb), 0.5);
 }
 
 .buttonDanger {
-  background-color: #c53030;
-  color: #ffffff;
-  box-shadow: 0 6px 15px rgba(197, 48, 48, 0.4);
+  background-color: var(--color-danger);
+  color: var(--color-white);
+  box-shadow: 0 6px 15px rgba(var(--color-danger-rgb), 0.4);
 }
 
 .buttonDanger:hover {
-  background-color: #9b2c2c;
+  background-color: var(--color-danger-mid);
   transform: translateY(-3px);
-  box-shadow: 0 8px 20px rgba(197, 48, 48, 0.5);
+  box-shadow: 0 8px 20px rgba(var(--color-danger-rgb), 0.5);
 }
 
 .buttonSuccess {
-  background-color: #38a169;
-  color: #ffffff;
-  box-shadow: 0 6px 15px rgba(56, 161, 105, 0.4);
+  background-color: var(--color-success);
+  color: var(--color-white);
+  box-shadow: 0 6px 15px rgba(var(--color-success-rgb), 0.4);
 }
 
 .buttonSuccess:hover {
-  background-color: #2f855a;
+  background-color: var(--color-success-mid);
   transform: translateY(-3px);
-  box-shadow: 0 8px 20px rgba(56, 161, 105, 0.5);
+  box-shadow: 0 8px 20px rgba(var(--color-success-rgb), 0.5);
 }
 
 .indexTipoCortes li .button {
@@ -192,7 +192,7 @@ h2 {
   flex-wrap: wrap;
   justify-content: center;
   align-items: center;
-  margin-top: 16px;
+  margin-top: var(--space-4);
 }
 
 
@@ -212,18 +212,18 @@ h2 {
 @media (min-width: 769px) {
   h2 {
     font-size: 2.5rem;
-    margin-bottom: 30px;
+    margin-bottom: var(--space-7);
   }
 
   .indexTipoCortes,
   .formContainer {
     max-width: 800px;
-    margin: 40px auto;
-    padding: 30px;
+    margin: var(--space-8) auto;
+    padding: var(--space-7);
   }
 
   .indexTipoCortes li {
-    padding: 20px;
+    padding: var(--space-5);
     gap: 10px;
   }
 
@@ -251,32 +251,32 @@ h2 {
   flex: 1;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .corteTitle {
   font-size: 1.2rem;
   font-weight: 700;
-  color: #2d3748;
-  margin-bottom: 4px;
+  color: var(--color-gray-700);
+  margin-bottom: var(--space-1);
 }
 
 .corteCode {
   font-size: 0.9rem;
-  color: #718096;
+  color: var(--color-gray-400);
   font-weight: 500;
 }
 
 .cortePrice {
   font-size: 1rem;
-  color: #38a169;
+  color: var(--color-success);
   font-weight: 600;
 }
 
 
 .actionButtons {
   display: flex;
-  gap: 8px;
+  gap: var(--space-2);
   flex-wrap: wrap;
   align-items: center;
   justify-content: flex-end;
@@ -285,25 +285,25 @@ h2 {
 
 .emptyState {
   text-align: center;
-  padding: 40px 20px;
-  color: #718096;
+  padding: var(--space-8) var(--space-5);
+  color: var(--color-gray-400);
   font-size: 1.1rem;
 }
 
 .loadingState {
   text-align: center;
-  padding: 40px 20px;
-  color: #718096;
+  padding: var(--space-8) var(--space-5);
+  color: var(--color-gray-400);
   font-size: 1.1rem;
   font-weight: 500;
 }
 
 
 .errorMessage {
-  background-color: #fed7d7;
-  color: #742a2a;
-  padding: 10px 12px;
+  background-color: var(--color-danger-bg);
+  color: var(--color-danger-dark);
+  padding: 10px var(--space-3);
   border-radius: 8px;
   margin-bottom: 15px;
-  border-left: 4px solid #e53e3e;
+  border-left: 4px solid var(--color-danger-bright);
 }

--- a/src/FRONT/views/components/Barber/appointments/barberAppointments.module.css
+++ b/src/FRONT/views/components/Barber/appointments/barberAppointments.module.css
@@ -2,11 +2,11 @@
 
 .appointmentsContainer {
   max-width: 100%;
-  margin: 12px 0;
-  padding: 12px;
-  background-color: #ffffff;
+  margin: var(--space-3) 0;
+  padding: var(--space-3);
+  background-color: var(--color-white);
   border-radius: 10px;
-  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.06);
+  box-shadow: 0 8px 18px rgba(var(--shadow-color), 0.06);
   animation: fadeIn 0.35s ease-out;
   display: flex;
   flex-direction: column;
@@ -23,14 +23,14 @@
 }
 
 .appointmentItem {
-  background-color: #f0f4f8;
-  border: 1px solid #e2e8f0;
+  background-color: var(--color-surface-light-1);
+  border: 1px solid var(--color-gray-100);
   border-radius: 8px;
-  padding: 16px;
-  margin-bottom: 12px;
+  padding: var(--space-4);
+  margin-bottom: var(--space-3);
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: var(--space-3);
   transition:
     transform 0.2s ease,
     box-shadow 0.2s ease;
@@ -38,75 +38,75 @@
 
 .appointmentItem:hover {
   transform: translateY(-3px);
-  box-shadow: 0 6px 15px rgba(0, 0, 0, 0.05);
+  box-shadow: 0 6px 15px rgba(var(--shadow-color), 0.05);
 }
 
 .appointmentDetails {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .detailRow {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   font-size: 0.95rem;
 }
 
 .detailLabel {
   font-weight: 600;
-  color: #4a5568;
+  color: var(--color-gray-450);
   min-width: 100px;
 }
 
 .detailValue {
-  color: #2d3748;
+  color: var(--color-gray-700);
 }
 
 .statusBadge {
-  color: white;
-  padding: 4px 12px;
-  border-radius: 12px;
+  color: var(--color-white);
+  padding: var(--space-1) var(--space-3);
+  border-radius: var(--radius-md);
   font-size: 0.85rem;
   font-weight: 600;
 }
 
 /* different status colors */
 .statusProgramado {
-  background-color: #4299e1; /* blue - appointment scheduled and active */
+  background-color: var(--color-primary-hover); /* blue - appointment scheduled and active */
 }
 
 .statusCancelado {
-  background-color: #e53e3e; /* red - canceled by the client */
+  background-color: var(--color-danger-bright); /* red - canceled by the client */
 }
 
 .statusCobrado {
-  background-color: #48bb78; /* green - done and paid */
+  background-color: var(--color-success-bright); /* green - done and paid */
 }
 
 .statusSinCobrar {
-  background-color: #ed8936; /* orange - done but not paid */
+  background-color: var(--color-warning-alt-2); /* orange - done but not paid */
 }
 
 .statusNoAsistido {
-  background-color: #718096; /* gray - no-show*/
+  background-color: var(--color-gray-400); /* gray - no-show*/
 }
 
 .appointmentActions {
   display: flex;
   flex-direction: column;
   gap: 10px;
-  margin-top: 8px;
+  margin-top: var(--space-2);
 }
 
 .deleteButton {
   width: 100%;
   padding: 10px;
-  background-color: #e53e3e;
-  color: white;
+  background-color: var(--color-danger-bright);
+  color: var(--color-white);
   border: none;
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   font-weight: 600;
   cursor: pointer;
   transition: background-color 0.2s;
@@ -115,31 +115,31 @@
 .updateButton {
   width: 100%;
   padding: 10px;
-  background-color: #4299e1;
-  color: white;
+  background-color: var(--color-primary-hover);
+  color: var(--color-white);
   border: none;
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   font-weight: 600;
   cursor: pointer;
   transition: background-color 0.2s;
 }
 
 .deleteButton:hover:not(:disabled) {
-  background-color: #c53030;
+  background-color: var(--color-danger);
 }
 
 .deleteButton:disabled {
-  background-color: #cbd5e0;
+  background-color: var(--color-gray-150);
   cursor: not-allowed;
   opacity: 0.6;
 }
 
 .updateButton:hover:not(:disabled) {
-  background-color: #4299e1;
+  background-color: var(--color-primary-hover);
 }
 
 .updateButton:disabled {
-  background-color: #cbd5e0;
+  background-color: var(--color-gray-150);
   cursor: not-allowed;
   opacity: 0.6;
 }
@@ -147,10 +147,10 @@
 .receiptButton {
   width: 100%;
   padding: 10px;
-  background-color: #2b6cb0;
-  color: white;
+  background-color: var(--color-primary);
+  color: var(--color-white);
   border: none;
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   font-weight: 600;
   cursor: pointer;
   transition:
@@ -159,21 +159,21 @@
 }
 
 .receiptButton:hover:not(:disabled) {
-  background-color: #2c5282;
+  background-color: var(--color-blue-dark);
   transform: translateY(-1px);
 }
 
 .emptyState {
   text-align: center;
-  padding: 30px;
-  color: #718096;
+  padding: var(--space-7);
+  color: var(--color-gray-400);
   font-size: 1rem;
 }
 
 .loadingState {
   text-align: center;
-  padding: 30px;
-  color: #718096;
+  padding: var(--space-7);
+  color: var(--color-gray-400);
   font-size: 1rem;
   font-style: italic;
 }
@@ -184,51 +184,51 @@
 }
 
 .modalTitle {
-  margin: 0 0 16px 0;
-  font-size: 18px;
+  margin: 0 0 var(--space-4) 0;
+  font-size: var(--font-size-lg);
   font-weight: 600;
-  color: white;
+  color: var(--color-white);
 }
 
 .modalButtons {
   display: flex;
-  gap: 12px;
+  gap: var(--space-3);
   justify-content: center;
   align-items: center;
 }
 
 .buttonCancel {
-  background: #718096;
-  color: white;
+  background: var(--color-gray-400);
+  color: var(--color-white);
   border: none;
-  padding: 12px 24px;
+  padding: var(--space-3) var(--space-6);
   border-radius: 8px;
   cursor: pointer;
-  font-size: 16px;
+  font-size: var(--font-size-md);
   font-weight: 600;
   min-width: 120px;
   transition: all 0.2s ease;
 }
 
 .buttonCancel:hover {
-  background: #4a5568;
+  background: var(--color-gray-450);
 }
 
 .buttonConfirm {
-  background: #e53e3e;
-  color: white;
+  background: var(--color-danger-bright);
+  color: var(--color-white);
   border: none;
-  padding: 12px 24px;
+  padding: var(--space-3) var(--space-6);
   border-radius: 8px;
   cursor: pointer;
-  font-size: 16px;
+  font-size: var(--font-size-md);
   font-weight: 600;
   min-width: 120px;
   transition: all 0.2s ease;
 }
 
 .buttonConfirm:hover {
-  background: #c53030;
+  background: var(--color-danger);
 }
 
 /* Animation */
@@ -248,13 +248,13 @@
 @media (min-width: 769px) {
   .appointmentsContainer {
     max-width: 500px;
-    margin: 40px auto;
-    padding: 30px;
+    margin: var(--space-8) auto;
+    padding: var(--space-7);
   }
 
   .appointmentItem {
-    padding: 20px;
-    gap: 12px;
+    padding: var(--space-5);
+    gap: var(--space-3);
     margin-bottom: 15px;
   }
 
@@ -273,12 +273,12 @@
 
   .deleteButton {
     width: auto;
-    padding: 10px 24px;
+    padding: 10px var(--space-6);
     min-width: 150px;
   }
 
   .emptyState {
-    padding: 40px;
+    padding: var(--space-8);
     font-size: 1.1rem;
   }
 }
@@ -290,7 +290,7 @@
   left: 0;
   right: 0;
   bottom: 0;
-  background: rgba(0, 0, 0, 0.7);
+  background: rgba(var(--shadow-color), 0.7);
   display: flex;
   justify-content: center;
   align-items: center;
@@ -299,34 +299,34 @@
 }
 
 .modalContent {
-  background: white;
-  border-radius: 12px;
+  background: var(--color-white);
+  border-radius: var(--radius-md);
   max-width: 600px;
   width: 90%;
   max-height: 90vh;
   overflow-y: auto;
-  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.2);
+  box-shadow: 0 10px 40px rgba(var(--shadow-color), 0.2);
 }
 
 .modalHeader {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 20px;
-  border-bottom: 1px solid #e2e8f0;
+  padding: var(--space-5);
+  border-bottom: 1px solid var(--color-gray-100);
 }
 
 .modalHeader h3 {
   margin: 0;
   font-size: 1.5rem;
-  color: #333;
+  color: var(--color-gray-600);
 }
 
 .closeButton {
   background: none;
   border: none;
   font-size: 2rem;
-  color: #666;
+  color: var(--color-gray-500);
   cursor: pointer;
   padding: 0;
   width: 40px;
@@ -341,41 +341,41 @@
 }
 
 .closeButton:hover {
-  background: #f0f0f0;
-  color: #333;
+  background: var(--color-surface-light-20);
+  color: var(--color-gray-600);
 }
 
 .modalBody {
-  padding: 20px;
+  padding: var(--space-5);
 }
 
 .currentAppointmentInfo {
-  background: #f0f4f8;
-  border-left: 4px solid #3182ce;
+  background: var(--color-surface-light-1);
+  border-left: 4px solid var(--color-blue-mid);
   padding: 15px;
-  margin-bottom: 20px;
+  margin-bottom: var(--space-5);
   border-radius: 4px;
-  color: #2d3748;
+  color: var(--color-gray-700);
   line-height: 1.6;
 }
 
 .currentAppointmentInfo strong {
-  color: #1a202c;
+  color: var(--color-gray-950);
 }
 
 .filtersContainer {
   display: flex;
-  gap: 12px;
-  margin-bottom: 16px;
+  gap: var(--space-3);
+  margin-bottom: var(--space-4);
   flex-wrap: wrap;
 }
 
 .filterSelect {
-  padding: 8px 12px;
-  border-radius: 6px;
-  border: 1px solid #e2e8f0;
-  background-color: #f7fafc;
-  color: #2d3748;
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-gray-100);
+  background-color: var(--color-surface-light-21);
+  color: var(--color-gray-700);
   font-size: 0.95rem;
   font-weight: 500;
   cursor: pointer;
@@ -384,11 +384,11 @@
 }
 
 .filterSelect:focus {
-  border-color: #4299e1;
+  border-color: var(--color-primary-hover);
 }
 
 @media (min-width: 769px) {
   .filtersContainer {
-    margin-bottom: 24px;
+    margin-bottom: var(--space-6);
   }
 }

--- a/src/FRONT/views/components/Barber/appointments/barberAvailability.module.css
+++ b/src/FRONT/views/components/Barber/appointments/barberAvailability.module.css
@@ -2,15 +2,15 @@
 
 .container {
   max-width: 100%;
-  margin: 12px 0;
-  padding: 20px 16px;
-  background-color: #ffffff;
+  margin: var(--space-3) 0;
+  padding: var(--space-5) var(--space-4);
+  background-color: var(--color-white);
   border-radius: 10px;
-  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.06);
+  box-shadow: 0 8px 18px rgba(var(--shadow-color), 0.06);
   animation: fadeIn 0.35s ease-out;
   display: flex;
   flex-direction: column;
-  gap: 20px;
+  gap: var(--space-5);
   margin-bottom: 60px;
 }
 
@@ -20,9 +20,9 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 4px;
-  padding-bottom: 16px;
-  border-bottom: 2px solid #e2e8f0;
+  gap: var(--space-1);
+  padding-bottom: var(--space-4);
+  border-bottom: 2px solid var(--color-gray-100);
 }
 
 .shopName {
@@ -30,13 +30,13 @@
   font-weight: 600;
   letter-spacing: 0.12em;
   text-transform: uppercase;
-  color: #2b6cb0;
+  color: var(--color-primary);
 }
 
 .pageTitle {
   font-size: 1.55rem;
   font-weight: 700;
-  color: #1a202c;
+  color: var(--color-gray-950);
   letter-spacing: -0.025em;
   margin: 0;
   text-align: center;
@@ -44,7 +44,7 @@
 
 .subtitle {
   font-size: 0.88rem;
-  color: #718096;
+  color: var(--color-gray-400);
   text-align: center;
   margin-top: -8px;
 }
@@ -54,19 +54,19 @@
 .form {
   display: flex;
   flex-direction: column;
-  gap: 20px;
+  gap: var(--space-5);
 }
 
 /*  Time-range sections (Desde / Hasta)  */
 
 .rangeSection {
-  background-color: #f7fafc;
-  border: 1px solid #e2e8f0;
+  background-color: var(--color-surface-light-21);
+  border: 1px solid var(--color-gray-100);
   border-radius: 8px;
-  padding: 14px 16px 16px;
+  padding: 14px var(--space-4) var(--space-4);
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 .sectionTitle {
@@ -74,16 +74,16 @@
   font-weight: 700;
   letter-spacing: 0.1em;
   text-transform: uppercase;
-  color: #2b6cb0;
-  margin: 0 0 4px;
-  padding-bottom: 8px;
-  border-bottom: 1.5px solid #bee3f8;
+  color: var(--color-primary);
+  margin: 0 0 var(--space-1);
+  padding-bottom: var(--space-2);
+  border-bottom: 1.5px solid var(--color-blue-soft);
 }
 
 .fieldsRow {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 /*  Field Group  */
@@ -98,12 +98,12 @@
 .label {
   font-size: 0.82rem;
   font-weight: 600;
-  color: #4a5568;
+  color: var(--color-gray-450);
 }
 
 .optional {
   font-weight: 400;
-  color: #a0aec0;
+  color: var(--color-gray-125);
   font-size: 0.78rem;
 }
 
@@ -124,7 +124,7 @@
 .checkbox {
   width: 17px;
   height: 17px;
-  accent-color: #2b6cb0;
+  accent-color: var(--color-primary);
   cursor: pointer;
   border-radius: 3px;
   flex-shrink: 0;
@@ -136,13 +136,13 @@
 .select,
 .textarea {
   width: 100%;
-  padding: 10px 12px;
-  border: 1px solid #cbd5e0;
-  border-radius: 6px;
+  padding: 10px var(--space-3);
+  border: 1px solid var(--color-gray-150);
+  border-radius: var(--radius-sm);
   font-size: 0.92rem;
   font-family: "Poppins", sans-serif;
-  color: #2d3748;
-  background-color: #ffffff;
+  color: var(--color-gray-700);
+  background-color: var(--color-white);
   transition:
     border-color 0.2s ease,
     box-shadow 0.2s ease;
@@ -151,14 +151,14 @@
 
 .input::placeholder,
 .textarea::placeholder {
-  color: #a0aec0;
+  color: var(--color-gray-125);
 }
 
 .input:focus,
 .select:focus,
 .textarea:focus {
-  border-color: #4299e1;
-  box-shadow: 0 0 0 3px rgba(66, 153, 225, 0.18);
+  border-color: var(--color-primary-hover);
+  box-shadow: 0 0 0 3px rgba(var(--color-primary-hover-rgb), 0.18);
 }
 
 /* Full-width input when inside dateRow */
@@ -176,7 +176,7 @@
 }
 
 .select option:first-child {
-  color: #a0aec0;
+  color: var(--color-gray-125);
 }
 
 .textarea {
@@ -189,7 +189,7 @@
 
 .divider {
   border: none;
-  border-top: 1px solid #e2e8f0;
+  border-top: 1px solid var(--color-gray-100);
   margin: 0;
 }
 
@@ -197,9 +197,9 @@
 
 .submitButton {
   width: 100%;
-  padding: 12px;
-  background-color: #2b6cb0;
-  color: #ffffff;
+  padding: var(--space-3);
+  background-color: var(--color-primary);
+  color: var(--color-white);
   border: none;
   border-radius: 8px;
   font-size: 1rem;
@@ -207,7 +207,7 @@
   font-family: "Poppins", sans-serif;
   cursor: pointer;
   letter-spacing: 0.02em;
-  box-shadow: 0 4px 12px rgba(43, 108, 176, 0.35);
+  box-shadow: 0 4px 12px rgba(var(--color-primary-rgb), 0.35);
   transition:
     background-color 0.2s ease,
     transform 0.2s ease,
@@ -215,18 +215,18 @@
 }
 
 .submitButton:hover:not(:disabled) {
-  background-color: #2c5282;
+  background-color: var(--color-blue-dark);
   transform: translateY(-2px);
-  box-shadow: 0 6px 16px rgba(43, 108, 176, 0.45);
+  box-shadow: 0 6px 16px rgba(var(--color-primary-rgb), 0.45);
 }
 
 .submitButton:active:not(:disabled) {
   transform: translateY(0);
-  box-shadow: 0 2px 8px rgba(43, 108, 176, 0.3);
+  box-shadow: 0 2px 8px rgba(var(--color-primary-rgb), 0.3);
 }
 
 .submitButton:disabled {
-  background-color: #cbd5e0;
+  background-color: var(--color-gray-150);
   cursor: not-allowed;
   box-shadow: none;
 }
@@ -249,7 +249,7 @@
 @media (min-width: 769px) {
   .container {
     max-width: 580px;
-    margin: 40px auto;
+    margin: var(--space-8) auto;
     padding: 32px 36px;
   }
 
@@ -259,7 +259,7 @@
 
   .fieldsRow {
     flex-direction: row;
-    gap: 16px;
+    gap: var(--space-4);
   }
 
   .fieldsRow .fieldGroup {

--- a/src/FRONT/views/components/Barber/appointments/branchAppointments.module.css
+++ b/src/FRONT/views/components/Barber/appointments/branchAppointments.module.css
@@ -1,8 +1,8 @@
 /* Branch Appointments Styles */
 body {
   font-family: "Inter", sans-serif;
-  background-color: #f8f8f8;
-  color: #333;
+  background-color: var(--color-surface-light-18);
+  color: var(--color-gray-600);
   margin: 0;
   padding: 10px;
   line-height: 1.6;
@@ -12,11 +12,11 @@ body {
 
 .appointmentsContainer {
   max-width: 100%;
-  margin: 12px 0;
-  padding: 12px;
-  background-color: #ffffff;
+  margin: var(--space-3) 0;
+  padding: var(--space-3);
+  background-color: var(--color-white);
   border-radius: 10px;
-  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.06);
+  box-shadow: 0 8px 18px rgba(var(--shadow-color), 0.06);
   animation: fadeIn 0.35s ease-out;
   display: flex;
   flex-direction: column;
@@ -27,9 +27,9 @@ body {
 
 .pageTitle {
   font-size: 1.6rem;
-  color: #1a202c;
+  color: var(--color-gray-950);
   text-align: center;
-  margin-bottom: 20px;
+  margin-bottom: var(--space-5);
   font-weight: 700;
   letter-spacing: -0.025em;
 }
@@ -42,14 +42,14 @@ body {
 }
 
 .appointmentItem {
-  background-color: #f0f4f8;
-  border: 1px solid #e2e8f0;
+  background-color: var(--color-surface-light-1);
+  border: 1px solid var(--color-gray-100);
   border-radius: 8px;
-  padding: 16px;
-  margin-bottom: 12px;
+  padding: var(--space-4);
+  margin-bottom: var(--space-3);
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: var(--space-3);
   transition:
     transform 0.2s ease,
     box-shadow 0.2s ease;
@@ -57,70 +57,70 @@ body {
 
 .appointmentItem:hover {
   transform: translateY(-3px);
-  box-shadow: 0 6px 15px rgba(0, 0, 0, 0.05);
+  box-shadow: 0 6px 15px rgba(var(--shadow-color), 0.05);
 }
 
 .appointmentDetails {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .detailRow {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   font-size: 0.95rem;
 }
 
 .detailLabel {
   font-weight: 600;
-  color: #4a5568;
+  color: var(--color-gray-450);
   min-width: 100px;
 }
 
 .detailValue {
-  color: #2d3748;
+  color: var(--color-gray-700);
 }
 
 .statusBadge {
-  color: white;
-  padding: 4px 12px;
-  border-radius: 12px;
+  color: var(--color-white);
+  padding: var(--space-1) var(--space-3);
+  border-radius: var(--radius-md);
   font-size: 0.85rem;
   font-weight: 600;
 }
 
 /* status colors */
 .statusProgramado {
-  background-color: #4299e1; /* blue - appointment scheduled and active */
+  background-color: var(--color-primary-hover); /* blue - appointment scheduled and active */
 }
 
 .statusCancelado {
-  background-color: #e53e3e; /* red - canceled by the client */
+  background-color: var(--color-danger-bright); /* red - canceled by the client */
 }
 
 .statusCobrado {
-  background-color: #48bb78; /* green - done and paid */
+  background-color: var(--color-success-bright); /* green - done and paid */
 }
 
 .statusSinCobrar {
-  background-color: #ed8936; /* orange - done but not paid*/
+  background-color: var(--color-warning-alt-2); /* orange - done but not paid*/
 }
 
 .statusNoAsistido {
-  background-color: #718096; /* gray - no-show */
+  background-color: var(--color-gray-400); /* gray - no-show */
 }
 
 .actionButtons {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: var(--space-3);
   margin-top: 15px;
   padding: 15px;
-  background-color: #f7fafc;
+  background-color: var(--color-surface-light-21);
   border-radius: 8px;
-  border: 1px solid #e2e8f0;
+  border: 1px solid var(--color-gray-100);
 }
 
 .formGroup {
@@ -131,49 +131,49 @@ body {
   display: block;
   margin-bottom: 6px;
   font-weight: 600;
-  color: #4a5568;
+  color: var(--color-gray-450);
   font-size: 0.9rem;
 }
 
 .formInput,
 .formSelect {
   width: 100%;
-  padding: 10px 12px;
-  border: 2px solid #cbd5e0;
+  padding: 10px var(--space-3);
+  border: 2px solid var(--color-gray-150);
   border-radius: 8px;
   font-size: 0.95rem;
-  color: #2d3748;
+  color: var(--color-gray-700);
   transition:
     border-color 0.3s ease,
     box-shadow 0.3s ease;
   box-sizing: border-box;
-  background-color: #ffffff;
+  background-color: var(--color-white);
 }
 
 /* specific Input to search for order number within the list */
 .searchInput {
   width: 100%;
-  padding: 8px 12px;
-  border: 2px solid #e2e8f0;
+  padding: var(--space-2) var(--space-3);
+  border: 2px solid var(--color-gray-100);
   border-radius: 8px;
   font-size: 0.95rem;
-  color: #2d3748;
-  background: #ffffff;
-  box-shadow: 0 2px 6px rgba(16, 24, 40, 0.03);
-  margin: 0 0 12px 0;
+  color: var(--color-gray-700);
+  background: var(--color-white);
+  box-shadow: 0 2px 6px rgba(var(--color-slate-800-rgb), 0.03);
+  margin: 0 0 var(--space-3) 0;
 }
 
 .searchInput:focus {
   outline: none;
-  border-color: #4299e1;
-  box-shadow: 0 0 0 4px rgba(66, 153, 225, 0.08);
+  border-color: var(--color-primary-hover);
+  box-shadow: 0 0 0 4px rgba(var(--color-primary-hover-rgb), 0.08);
 }
 
 .formInput:focus,
 .formSelect:focus {
   outline: none;
-  border-color: #4299e1;
-  box-shadow: 0 0 0 3px rgba(66, 153, 225, 0.1);
+  border-color: var(--color-primary-hover);
+  box-shadow: 0 0 0 3px rgba(var(--color-primary-hover-rgb), 0.1);
 }
 
 .button {
@@ -198,19 +198,19 @@ body {
 
 
 .buttonSuccess {
-  background-color: #38a169;
-  color: #ffffff;
-  box-shadow: 0 6px 15px rgba(56, 161, 105, 0.4);
+  background-color: var(--color-success);
+  color: var(--color-white);
+  box-shadow: 0 6px 15px rgba(var(--color-success-rgb), 0.4);
 }
 
 .buttonSuccess:hover {
-  background-color: #2f855a;
+  background-color: var(--color-success-mid);
   transform: translateY(-3px);
-  box-shadow: 0 8px 20px rgba(56, 161, 105, 0.5);
+  box-shadow: 0 8px 20px rgba(var(--color-success-rgb), 0.5);
 }
 
 .buttonSuccess:disabled {
-  background-color: #cbd5e0;
+  background-color: var(--color-gray-150);
   cursor: not-allowed;
   opacity: 0.6;
   transform: none;
@@ -218,19 +218,19 @@ body {
 }
 
 .buttonInfo {
-  background-color: #2b6cb0;
-  color: #ffffff;
-  box-shadow: 0 6px 15px rgba(43, 108, 176, 0.4);
+  background-color: var(--color-primary);
+  color: var(--color-white);
+  box-shadow: 0 6px 15px rgba(var(--color-primary-rgb), 0.4);
 }
 
 .buttonInfo:hover {
-  background-color: #2c5282;
+  background-color: var(--color-blue-dark);
   transform: translateY(-3px);
-  box-shadow: 0 8px 20px rgba(43, 108, 176, 0.5);
+  box-shadow: 0 8px 20px rgba(var(--color-primary-rgb), 0.5);
 }
 
 .buttonInfo:disabled {
-  background-color: #cbd5e0;
+  background-color: var(--color-gray-150);
   cursor: not-allowed;
   opacity: 0.6;
   transform: none;
@@ -238,19 +238,19 @@ body {
 }
 
 .buttonWarning {
-  background-color: #dd6b20;
-  color: #ffffff;
-  box-shadow: 0 6px 15px rgba(221, 107, 32, 0.4);
+  background-color: var(--color-warning);
+  color: var(--color-white);
+  box-shadow: 0 6px 15px rgba(var(--color-warning-rgb), 0.4);
 }
 
 .buttonWarning:hover {
-  background-color: #c05621;
+  background-color: var(--color-warning-dark);
   transform: translateY(-3px);
-  box-shadow: 0 8px 20px rgba(221, 107, 32, 0.5);
+  box-shadow: 0 8px 20px rgba(var(--color-warning-rgb), 0.5);
 }
 
 .buttonWarning:disabled {
-  background-color: #cbd5e0;
+  background-color: var(--color-gray-150);
   cursor: not-allowed;
   opacity: 0.6;
   transform: none;
@@ -260,8 +260,8 @@ body {
 .loadingState,
 .emptyState {
   text-align: center;
-  padding: 30px;
-  color: #718096;
+  padding: var(--space-7);
+  color: var(--color-gray-400);
   font-size: 1rem;
 }
 
@@ -283,22 +283,22 @@ body {
   margin: 0 0 10px 0;
   font-size: 1.3rem;
   font-weight: 700;
-  color: #1a202c;
+  color: var(--color-gray-950);
   line-height: 1.3;
 }
 
 .modalDescription {
-  margin: 0 0 20px 0;
+  margin: 0 0 var(--space-5) 0;
   font-size: 1rem;
   font-weight: 400;
-  color: #4a5568;
+  color: var(--color-gray-450);
   line-height: 1.5;
 }
 
 .modalButtons {
   display: flex;
   flex-direction: row;
-  gap: 12px;
+  gap: var(--space-3);
   justify-content: center;
   align-items: stretch;
   width: 100%;
@@ -306,10 +306,10 @@ body {
 
 .modalButtonCancel {
   flex: 1;
-  background: #e2e8f0;
-  color: #2d3748;
-  border: 1px solid #cbd5e0;
-  padding: 12px 20px;
+  background: var(--color-gray-100);
+  color: var(--color-gray-700);
+  border: 1px solid var(--color-gray-150);
+  padding: var(--space-3) var(--space-5);
   border-radius: 8px;
   cursor: pointer;
   font-size: 1rem;
@@ -321,23 +321,23 @@ body {
 }
 
 .modalButtonCancel:hover {
-  background: #cbd5e0;
-  border-color: #a0aec0;
+  background: var(--color-gray-150);
+  border-color: var(--color-gray-125);
   transform: translateY(-1px);
 }
 
 .modalButtonConfirm {
   flex: 1;
-  background: linear-gradient(135deg, #38a169 0%, #2f855a 100%);
-  color: white;
+  background: linear-gradient(135deg, var(--color-success) 0%, var(--color-success-mid) 100%);
+  color: var(--color-white);
   border: none;
-  padding: 12px 20px;
+  padding: var(--space-3) var(--space-5);
   border-radius: 8px;
   cursor: pointer;
   font-size: 1rem;
   font-weight: 600;
   transition: all 0.2s ease;
-  box-shadow: 0 4px 10px rgba(56, 161, 105, 0.3);
+  box-shadow: 0 4px 10px rgba(var(--color-success-rgb), 0.3);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -345,8 +345,8 @@ body {
 }
 
 .modalButtonConfirm:hover {
-  background: linear-gradient(135deg, #2f855a 0%, #276749 100%);
-  box-shadow: 0 6px 14px rgba(56, 161, 105, 0.4);
+  background: linear-gradient(135deg, var(--color-success-mid) 0%, var(--color-success-mid-2) 100%);
+  box-shadow: 0 6px 14px rgba(var(--color-success-rgb), 0.4);
   transform: translateY(-2px);
 }
 
@@ -365,29 +365,29 @@ body {
 
 /* styles for price and discount information */
 .priceInfo {
-  background-color: #f7fafc;
-  border: 2px solid #cbd5e0;
+  background-color: var(--color-surface-light-21);
+  border: 2px solid var(--color-gray-150);
   border-radius: 8px;
-  padding: 12px;
-  margin-bottom: 12px;
+  padding: var(--space-3);
+  margin-bottom: var(--space-3);
 }
 
 .priceLine {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 8px 0;
+  padding: var(--space-2) 0;
   font-size: 0.95rem;
 }
 
 .priceLabel {
   font-weight: 500;
-  color: #4a5568;
+  color: var(--color-gray-450);
 }
 
 .priceValue {
   font-weight: 600;
-  color: #2d3748;
+  color: var(--color-gray-700);
   text-align: right;
 }
 
@@ -395,24 +395,24 @@ body {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 8px;
-  background: linear-gradient(135deg, #edf2f7 0%, #e2e8f0 100%);
-  border: 1px solid #cbd5e0;
-  border-radius: 6px;
-  padding: 8px 10px;
+  gap: var(--space-2);
+  background: linear-gradient(135deg, var(--color-surface-light-22) 0%, var(--color-gray-100) 100%);
+  border: 1px solid var(--color-gray-150);
+  border-radius: var(--radius-sm);
+  padding: var(--space-2) 10px;
   margin: 10px 0;
   font-size: 0.9rem;
 }
 
 .categoryName {
   font-weight: 600;
-  color: #2d3748;
+  color: var(--color-gray-700);
 }
 
 .discountBadge {
-  background-color: #e74c3c;
-  color: white;
-  padding: 4px 8px;
+  background-color: var(--color-danger-alt);
+  color: var(--color-white);
+  padding: var(--space-1) var(--space-2);
   border-radius: 4px;
   font-weight: 700;
   font-size: 0.85rem;
@@ -421,25 +421,25 @@ body {
 /* DESKTOP */
 @media (min-width: 769px) {
   body {
-    padding: 20px;
+    padding: var(--space-5);
   }
 
   .pageTitle {
     font-size: 2.5rem;
-    margin-bottom: 30px;
+    margin-bottom: var(--space-7);
   }
 
   .appointmentsContainer {
     max-width: 500px;
-    margin: 40px auto;
-    padding: 30px;
+    margin: var(--space-8) auto;
+    padding: var(--space-7);
   }
 .appointmentItem {
     flex-direction: column;
     justify-content: space-between;
     align-items: stretch; 
-    padding: 20px;
-    gap: 20px; 
+    padding: var(--space-5);
+    gap: var(--space-5); 
     margin-bottom: 15px;
     overflow: hidden; 
   }
@@ -478,13 +478,13 @@ body {
 
   .loadingState,
   .emptyState {
-    padding: 40px;
+    padding: var(--space-8);
     font-size: 1.1rem;
   }
 
   .emptyState p {
     font-size: 1.1rem;
-    margin-bottom: 20px;
+    margin-bottom: var(--space-5);
   }
 
   .modalTitle {
@@ -502,7 +502,7 @@ body {
 
   .modalButtonCancel,
   .modalButtonConfirm {
-    padding: 12px 24px;
+    padding: var(--space-3) var(--space-6);
     font-size: 1rem;
     flex: 0 1 auto;
     min-width: 140px;

--- a/src/FRONT/views/components/Barber/appointments/branchAppointments.tsx
+++ b/src/FRONT/views/components/Barber/appointments/branchAppointments.tsx
@@ -176,7 +176,7 @@ const CheckoutForm: React.FC<{
                 padding: "24px",
                 borderRadius: "12px",
                 boxShadow: "0 10px 30px rgba(0, 0, 0, 0.15)",
-                background: "#ffffff",
+                background: "var(--color-white)",
               },
             },
           );
@@ -186,7 +186,7 @@ const CheckoutForm: React.FC<{
               <div className={styles.modalContainer}>
                 <p className={styles.modalTitle}>Turno cobrado con éxito</p>
                 {/* <p className={styles.modalDescription}>
-                  <span style={{ color: "#e67e22" }}>
+                  <span style={{ color: "var(--color-warning-alt)" }}>
                     Factura pendiente
                     {facturacionError ? `: ${facturacionError}` : ""}
                   </span>
@@ -220,7 +220,7 @@ const CheckoutForm: React.FC<{
                 padding: "24px",
                 borderRadius: "12px",
                 boxShadow: "0 10px 30px rgba(0, 0, 0, 0.15)",
-                background: "#ffffff",
+                background: "var(--color-white)",
               },
             },
           );
@@ -293,7 +293,7 @@ const CheckoutForm: React.FC<{
           padding: "24px",
           borderRadius: "12px",
           boxShadow: "0 10px 30px rgba(0, 0, 0, 0.15)",
-          background: "#ffffff",
+          background: "var(--color-white)",
         },
       },
     );
@@ -376,7 +376,7 @@ const CheckoutForm: React.FC<{
                   </div>
                   <div
                     className={styles.priceLine}
-                    style={{ color: "#e74c3c" }}
+                    style={{ color: "var(--color-danger-alt)" }}
                   >
                     <span className={styles.priceLabel}>Descuento:</span>
                     <span className={styles.priceValue}>
@@ -386,7 +386,7 @@ const CheckoutForm: React.FC<{
                   <div
                     className={styles.priceLine}
                     style={{
-                      borderTop: "2px solid #bdc3c7",
+                      borderTop: "2px solid var(--color-gray-150)",
                       paddingTop: "8px",
                     }}
                   >
@@ -398,7 +398,7 @@ const CheckoutForm: React.FC<{
                     </span>
                     <span
                       className={styles.priceValue}
-                      style={{ fontWeight: "bold", color: "#27ae60" }}
+                      style={{ fontWeight: "bold", color: "var(--color-success-alt)" }}
                     >
                       ${precioFinal.toFixed(2)}
                     </span>
@@ -423,7 +423,7 @@ const CheckoutForm: React.FC<{
             min="0"
             value={precioFinal.toFixed(2)}
             readOnly
-            style={{ backgroundColor: "#ecf0f1", cursor: "not-allowed" }}
+            style={{ backgroundColor: "var(--color-surface-light-23)", cursor: "not-allowed" }}
           />
         </div>
 
@@ -692,7 +692,7 @@ const BranchAppointments: React.FC = () => {
               padding: "24px",
               borderRadius: "12px",
               boxShadow: "0 10px 30px rgba(0, 0, 0, 0.15)",
-              background: "#ffffff",
+              background: "var(--color-white)",
             },
           },
         );
@@ -751,7 +751,7 @@ const BranchAppointments: React.FC = () => {
           padding: "24px",
           borderRadius: "12px",
           boxShadow: "0 10px 30px rgba(0, 0, 0, 0.15)",
-          background: "#ffffff",
+          background: "var(--color-white)",
         },
       },
     );

--- a/src/FRONT/views/components/Barber/appointments/receiptViewer.module.css
+++ b/src/FRONT/views/components/Barber/appointments/receiptViewer.module.css
@@ -1,10 +1,10 @@
 .container {
   max-width: 100%;
-  margin: 12px 0;
-  padding: 12px;
-  background-color: #ffffff;
+  margin: var(--space-3) 0;
+  padding: var(--space-3);
+  background-color: var(--color-white);
   border-radius: 10px;
-  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.06);
+  box-shadow: 0 8px 18px rgba(var(--shadow-color), 0.06);
   animation: fadeIn 0.35s ease-out;
   display: flex;
   flex-direction: column;
@@ -17,14 +17,14 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 10px 16px;
-  border-bottom: 1px solid #e2e8f0;
-  gap: 12px;
+  padding: 10px var(--space-4);
+  border-bottom: 1px solid var(--color-gray-100);
+  gap: var(--space-3);
 }
 
 .title {
   font-size: 1.1rem;
-  color: #2d3748;
+  color: var(--color-gray-700);
   margin: 0;
   font-weight: 700;
   text-align: center;
@@ -35,8 +35,8 @@
   flex-direction: column;
   align-items: center;
   gap: 6px;
-  padding: 12px 16px 8px;
-  border-bottom: 1px solid #e2e8f0;
+  padding: var(--space-3) var(--space-4) var(--space-2);
+  border-bottom: 1px solid var(--color-gray-100);
 }
 
 .voucherInfoRow {
@@ -48,17 +48,17 @@
 
 .voucherInfo {
   font-size: 0.78rem;
-  color: #718096;
+  color: var(--color-gray-400);
   font-weight: 500;
   white-space: nowrap;
 }
 
 .backButton {
-  padding: 8px 16px;
-  background-color: #718096;
-  color: white;
+  padding: var(--space-2) var(--space-4);
+  background-color: var(--color-gray-400);
+  color: var(--color-white);
   border: none;
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   font-weight: 600;
   font-size: 0.9rem;
   cursor: pointer;
@@ -68,16 +68,16 @@
 }
 
 .backButton:hover {
-  background-color: #4a5568;
+  background-color: var(--color-gray-450);
   transform: translateY(-1px);
 }
 
 .downloadButton {
-  padding: 8px 16px;
-  background-color: #2b6cb0;
-  color: white;
+  padding: var(--space-2) var(--space-4);
+  background-color: var(--color-primary);
+  color: var(--color-white);
   border: none;
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   font-weight: 600;
   font-size: 0.9rem;
   cursor: pointer;
@@ -87,13 +87,13 @@
 }
 
 .downloadButton:hover {
-  background-color: #2c5282;
+  background-color: var(--color-blue-dark);
   transform: translateY(-1px);
 }
 
 .pdfWrapper {
   flex: 1;
-  padding: 12px;
+  padding: var(--space-3);
   display: flex;
   align-items: stretch;
   min-height: 0;
@@ -102,7 +102,7 @@
 .pdfFrame {
   width: 100%;
   height: 100%;
-  border: 1px solid #e2e8f0;
+  border: 1px solid var(--color-gray-100);
   border-radius: 8px;
 }
 
@@ -112,23 +112,23 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: 60px 20px;
-  color: #718096;
+  padding: 60px var(--space-5);
+  color: var(--color-gray-400);
   font-size: 1rem;
-  gap: 16px;
+  gap: var(--space-4);
   flex: 1;
 }
 
 .errorState {
-  color: #e53e3e;
+  color: var(--color-danger-bright);
 }
 
 /* DESKTOP */
 @media (min-width: 769px) {
   .container {
     max-width: 100%;
-    margin: 40px auto;
-    padding: 20px;
+    margin: var(--space-8) auto;
+    padding: var(--space-5);
     height: calc(100vh - 180px);
   }
 

--- a/src/FRONT/views/components/Client/appointments/appointments.module.css
+++ b/src/FRONT/views/components/Client/appointments/appointments.module.css
@@ -4,8 +4,8 @@
 /* General Body and Root Styling */
 body {
   font-family: "Inter", sans-serif;
-  background-color: #f8f8f8;
-  color: #333;
+  background-color: var(--color-surface-light-18);
+  color: var(--color-gray-600);
   margin: 0;
   padding: 10px;
   line-height: 1.6;
@@ -16,9 +16,9 @@ body {
 /* Headings */
 .pageTitle, h2 {
   font-size: 2rem;
-  color: #1a202c;
+  color: var(--color-gray-950);
   text-align: center;
-  margin-bottom: 20px;
+  margin-bottom: var(--space-5);
   font-weight: 700;
   letter-spacing: -0.025em;
 }
@@ -27,11 +27,11 @@ body {
 /* Container for IndexTurnos */
 .indexAppointments {
   max-width: 100%;
-  margin: 20px 0;
+  margin: var(--space-5) 0;
   padding: 15px;
-  background-color: #ffffff;
-  border-radius: 12px;
-  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.08);
+  background-color: var(--color-white);
+  border-radius: var(--radius-md);
+  box-shadow: 0 10px 25px var(--shadow-sm);
   animation: fadeIn 0.5s ease-out;
 }
 
@@ -42,40 +42,40 @@ body {
 }
 
 .indexAppointments li {
-  background-color: #f0f4f8;
-  border: 1px solid #e2e8f0;
+  background-color: var(--color-surface-light-1);
+  border: 1px solid var(--color-gray-100);
   border-radius: 8px;
-  padding: 12px;
+  padding: var(--space-3);
   margin-bottom: 10px;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--space-2);
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
 .indexAppointments li:hover {
   transform: translateY(-3px);
-  box-shadow: 0 6px 15px rgba(0, 0, 0, 0.05);
+  box-shadow: 0 6px 15px rgba(var(--shadow-color), 0.05);
 }
 
 .indexAppointments li strong {
   font-size: 1.1rem;
-  color: #2d3748;
+  color: var(--color-gray-700);
 }
 
 .indexAppointments li p {
   margin: 0;
-  color: #4a5568;
+  color: var(--color-gray-450);
 }
 
 /* Form Styles (for Create and Modificar) */
 .formContainer {
   max-width: 100%;
-  margin: 20px auto;
+  margin: var(--space-5) auto;
   padding: 15px;
-  background-color: #ffffff;
-  border-radius: 12px;
-  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.08);
+  background-color: var(--color-white);
+  border-radius: var(--radius-md);
+  box-shadow: 0 10px 25px var(--shadow-sm);
   animation: fadeIn 0.5s ease-out;
 }
 
@@ -87,41 +87,41 @@ body {
   display: block;
   margin-bottom: 6px;
   font-weight: 600;
-  color: #4a5568;
+  color: var(--color-gray-450);
   font-size: 0.95rem;
 }
 
 .formInput {
   width: 100%;
-  padding: 10px 12px;
-  border: 2px solid #a0aec0;
+  padding: 10px var(--space-3);
+  border: 2px solid var(--color-gray-125);
   border-radius: 8px;
   font-size: 0.95rem;
-  color: #2d3748;
+  color: var(--color-gray-700);
   transition: border-color 0.3s ease, box-shadow 0.3s ease;
   box-sizing: border-box;
-  box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.1);
+  box-shadow: inset 0 1px 3px var(--shadow-md);
 }
 
 .formInput:focus, .formSelect:focus {
   outline: none;
-  border-color: #4299e1;
-  box-shadow: 0 0 0 4px rgba(66, 153, 225, 0.6);
-  background-color: #e6f4ff;
+  border-color: var(--color-primary-hover);
+  box-shadow: 0 0 0 4px rgba(var(--color-primary-hover-rgb), 0.6);
+  background-color: var(--color-surface-light-4);
 }
 
 /* Select styles */
 .formSelect {
   width: 100%;
-  padding: 10px 12px;
-  border: 2px solid #a0aec0;
+  padding: 10px var(--space-3);
+  border: 2px solid var(--color-gray-125);
   border-radius: 8px;
   font-size: 0.95rem;
-  color: #2d3748;
+  color: var(--color-gray-700);
   transition: border-color 0.3s ease, box-shadow 0.3s ease;
   box-sizing: border-box;
-  box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.1);
-  background-color: #ffffff;
+  box-shadow: inset 0 1px 3px var(--shadow-md);
+  background-color: var(--color-white);
 }
 
 /* Buttons */
@@ -143,39 +143,39 @@ body {
 }
 
 .buttonPrimary {
-  background-color: #2b6cb0;
-  color: #ffffff;
-  box-shadow: 0 6px 15px rgba(43, 108, 176, 0.4);
+  background-color: var(--color-primary);
+  color: var(--color-white);
+  box-shadow: 0 6px 15px rgba(var(--color-primary-rgb), 0.4);
 }
 
 .buttonPrimary:hover {
-  background-color: #2c5282;
+  background-color: var(--color-blue-dark);
   transform: translateY(-3px);
-  box-shadow: 0 8px 20px rgba(43, 108, 176, 0.5);
+  box-shadow: 0 8px 20px rgba(var(--color-primary-rgb), 0.5);
 }
 
 .buttonDanger {
-  background-color: #c53030;
-  color: #ffffff;
-  box-shadow: 0 6px 15px rgba(197, 48, 48, 0.4);
+  background-color: var(--color-danger);
+  color: var(--color-white);
+  box-shadow: 0 6px 15px rgba(var(--color-danger-rgb), 0.4);
 }
 
 .buttonDanger:hover {
-  background-color: #9b2c2c;
+  background-color: var(--color-danger-mid);
   transform: translateY(-3px);
-  box-shadow: 0 8px 20px rgba(197, 48, 48, 0.5);
+  box-shadow: 0 8px 20px rgba(var(--color-danger-rgb), 0.5);
 }
 
 .buttonSuccess {
-  background-color: #38a169;
-  color: #ffffff;
-  box-shadow: 0 6px 15px rgba(56, 161, 105, 0.4);
+  background-color: var(--color-success);
+  color: var(--color-white);
+  box-shadow: 0 6px 15px rgba(var(--color-success-rgb), 0.4);
 }
 
 .buttonSuccess:hover {
-  background-color: #2f855a;
+  background-color: var(--color-success-mid);
   transform: translateY(-3px);
-  box-shadow: 0 8px 20px rgba(56, 161, 105, 0.5);
+  box-shadow: 0 8px 20px rgba(var(--color-success-rgb), 0.5);
 }
 
 /* Specific adjustment for buttons within list items in IndexTurnos */
@@ -204,44 +204,44 @@ body {
 .appointmentTitle {
   font-size: 1.1rem;
   font-weight: 700;
-  color: #2d3748;
-  margin-bottom: 4px;
+  color: var(--color-gray-700);
+  margin-bottom: var(--space-1);
 }
 
 .appointmentCode {
   font-size: 0.85rem;
-  color: #718096;
+  color: var(--color-gray-400);
   font-weight: 500;
 }
 
 .appointmentDetails {
-  color: #4a5568;
+  color: var(--color-gray-450);
   line-height: 1.5;
-  margin-top: 4px;
+  margin-top: var(--space-1);
 }
 
 .appointmentDate {
-  color: #2d3748;
+  color: var(--color-gray-700);
   font-weight: 600;
 }
 
 .appointmentTime {
-  color: #2b6cb0;
+  color: var(--color-primary);
   font-weight: 600;
 }
 
 /* Loading and empty states */
 .loadingState {
   text-align: center;
-  padding: 30px;
-  color: #718096;
+  padding: var(--space-7);
+  color: var(--color-gray-400);
   font-size: 1rem;
 }
 
 .emptyState {
   text-align: center;
-  padding: 30px;
-  color: #718096;
+  padding: var(--space-7);
+  color: var(--color-gray-400);
 }
 
 .emptyState p {
@@ -252,11 +252,11 @@ body {
 /* Main Turnos styling */
 .mainAppointments {
   max-width: 100%;
-  margin: 20px 0;
+  margin: var(--space-5) 0;
   padding: 15px;
-  background-color: #ffffff;
-  border-radius: 12px;
-  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.08);
+  background-color: var(--color-white);
+  border-radius: var(--radius-md);
+  box-shadow: 0 10px 25px var(--shadow-sm);
   animation: fadeIn 0.5s ease-out;
 }
 
@@ -264,21 +264,21 @@ body {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
   gap: 10px;
-  margin-top: 20px;
+  margin-top: var(--space-5);
 }
 
 .mainAppointmentsCard {
-  background-color: #f0f4f8;
-  border: 1px solid #e2e8f0;
+  background-color: var(--color-surface-light-1);
+  border: 1px solid var(--color-gray-100);
   border-radius: 8px;
-  padding: 12px;
+  padding: var(--space-3);
   text-align: center;
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
 .mainAppointmentsCard:hover {
   transform: translateY(-3px);
-  box-shadow: 0 6px 15px rgba(0, 0, 0, 0.05);
+  box-shadow: 0 6px 15px rgba(var(--shadow-color), 0.05);
 }
 /* Animations */
 @keyframes fadeIn {
@@ -295,39 +295,39 @@ body {
 
 /* Success message styling */
 .successMessage {
-  background-color: #c6f6d5;
-  color: #22543d;
-  padding: 10px 12px;
+  background-color: var(--color-success-bg);
+  color: var(--color-success-dark);
+  padding: 10px var(--space-3);
   border-radius: 8px;
   margin-bottom: 15px;
-  border-left: 4px solid #38a169;
+  border-left: 4px solid var(--color-success);
 }
 
 /* Error message styling */
 .errorMessage {
-  background-color: #fed7d7;
-  color: #742a2a;
-  padding: 10px 12px;
+  background-color: var(--color-danger-bg);
+  color: var(--color-danger-dark);
+  padding: 10px var(--space-3);
   border-radius: 8px;
   margin-bottom: 15px;
-  border-left: 4px solid #e53e3e;
+  border-left: 4px solid var(--color-danger-bright);
 }
 /* Responsive adjustments */
 @media (min-width: 769px) {
   .pageTitle,
   h2 {
     font-size: 2.5rem;
-    margin-bottom: 30px;
+    margin-bottom: var(--space-7);
   }
   .indexAppointments,
   .formContainer,
   .mainAppointments {
     max-width: 800px;
-    margin: 40px auto;
-    padding: 30px;
+    margin: var(--space-8) auto;
+    padding: var(--space-7);
   }
   .indexAppointments li {
-    padding: 20px;
+    padding: var(--space-5);
     gap: 10px;
     margin-bottom: 15px;
   }
@@ -347,24 +347,24 @@ body {
   }
   .mainAppointmentsGrid {
     grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-    gap: 20px;
-    margin-top: 30px;
+    gap: var(--space-5);
+    margin-top: var(--space-7);
   }
   .mainAppointmentsCard {
-    padding: 20px;
+    padding: var(--space-5);
   }
   .loadingState,
   .emptyState {
-    padding: 40px;
+    padding: var(--space-8);
     font-size: 1.1rem;
   }
   .emptyState p {
     font-size: 1.1rem;
-    margin-bottom: 20px;
+    margin-bottom: var(--space-5);
   }
   .successMessage,
   .errorMessage {
-    padding: 12px 16px;
-    margin-bottom: 20px;
+    padding: var(--space-3) var(--space-4);
+    margin-bottom: var(--space-5);
   }
 }

--- a/src/FRONT/views/components/Client/appointments/receiptViewer.module.css
+++ b/src/FRONT/views/components/Client/appointments/receiptViewer.module.css
@@ -1,10 +1,10 @@
 .container {
   max-width: 100%;
-  margin: 12px 0;
-  padding: 12px;
-  background-color: #ffffff;
+  margin: var(--space-3) 0;
+  padding: var(--space-3);
+  background-color: var(--color-white);
   border-radius: 10px;
-  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.06);
+  box-shadow: 0 8px 18px rgba(var(--shadow-color), 0.06);
   animation: fadeIn 0.35s ease-out;
   display: flex;
   flex-direction: column;
@@ -17,14 +17,14 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 10px 16px;
-  border-bottom: 1px solid #e2e8f0;
-  gap: 12px;
+  padding: 10px var(--space-4);
+  border-bottom: 1px solid var(--color-gray-100);
+  gap: var(--space-3);
 }
 
 .title {
   font-size: 1.1rem;
-  color: #2d3748;
+  color: var(--color-gray-700);
   margin: 0;
   font-weight: 700;
   text-align: center;
@@ -35,8 +35,8 @@
   flex-direction: column;
   align-items: center;
   gap: 6px;
-  padding: 12px 16px 8px;
-  border-bottom: 1px solid #e2e8f0;
+  padding: var(--space-3) var(--space-4) var(--space-2);
+  border-bottom: 1px solid var(--color-gray-100);
 }
 
 .voucherInfoRow {
@@ -48,17 +48,17 @@
 
 .voucherInfo {
   font-size: 0.78rem;
-  color: #718096;
+  color: var(--color-gray-400);
   font-weight: 500;
   white-space: nowrap;
 }
 
 .backButton {
-  padding: 8px 16px;
-  background-color: #718096;
-  color: white;
+  padding: var(--space-2) var(--space-4);
+  background-color: var(--color-gray-400);
+  color: var(--color-white);
   border: none;
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   font-weight: 600;
   font-size: 0.9rem;
   cursor: pointer;
@@ -68,16 +68,16 @@
 }
 
 .backButton:hover {
-  background-color: #4a5568;
+  background-color: var(--color-gray-450);
   transform: translateY(-1px);
 }
 
 .downloadButton {
-  padding: 8px 16px;
-  background-color: #2b6cb0;
-  color: white;
+  padding: var(--space-2) var(--space-4);
+  background-color: var(--color-primary);
+  color: var(--color-white);
   border: none;
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   font-weight: 600;
   font-size: 0.9rem;
   cursor: pointer;
@@ -87,13 +87,13 @@
 }
 
 .downloadButton:hover {
-  background-color: #2c5282;
+  background-color: var(--color-blue-dark);
   transform: translateY(-1px);
 }
 
 .pdfWrapper {
   flex: 1;
-  padding: 12px;
+  padding: var(--space-3);
   display: flex;
   align-items: stretch;
   min-height: 0;
@@ -102,7 +102,7 @@
 .pdfFrame {
   width: 100%;
   height: 100%;
-  border: 1px solid #e2e8f0;
+  border: 1px solid var(--color-gray-100);
   border-radius: 8px;
 }
 
@@ -112,23 +112,23 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: 60px 20px;
-  color: #718096;
+  padding: 60px var(--space-5);
+  color: var(--color-gray-400);
   font-size: 1rem;
-  gap: 16px;
+  gap: var(--space-4);
   flex: 1;
 }
 
 .errorState {
-  color: #e53e3e;
+  color: var(--color-danger-bright);
 }
 
 /* DESKTOP */
 @media (min-width: 769px) {
   .container {
     max-width: 100%;
-    margin: 40px auto;
-    padding: 20px;
+    margin: var(--space-8) auto;
+    padding: var(--space-5);
     height: calc(100vh - 180px);
   }
 

--- a/src/FRONT/views/components/Client/barbersByBranch.module.css
+++ b/src/FRONT/views/components/Client/barbersByBranch.module.css
@@ -1,10 +1,10 @@
 .barbersContainer {
     max-width: 100%;
-    margin: 20px 0;
+    margin: var(--space-5) 0;
     padding: 15px;
-    background-color: #ffffff;
-    border-radius: 12px;
-    box-shadow: 0 10px 25px rgba(0, 0, 0, 0.08);
+    background-color: var(--color-white);
+    border-radius: var(--radius-md);
+    box-shadow: 0 10px 25px var(--shadow-sm);
     animation: fadeIn 0.5s ease-out;
     display: flex;
     flex-direction: column;
@@ -14,12 +14,12 @@
 .branchInfo {
     width: 100%;
     text-align: center;
-    background: #f0f4f8;
-    border: 1px solid rgba(43, 108, 176, 0.08);
-    padding: 12px 16px;
+    background: var(--color-surface-light-1);
+    border: 1px solid rgba(var(--color-primary-rgb), 0.08);
+    padding: var(--space-3) var(--space-4);
     border-radius: 10px;
     margin-bottom: 14px;
-    box-shadow: 0 6px 18px rgba(43, 108, 176, 0.04);
+    box-shadow: 0 6px 18px rgba(var(--color-primary-rgb), 0.04);
 }
 
 .infoRow {
@@ -35,14 +35,14 @@
 .branchInfo h3 {
     margin: 0;
     font-size: 1.05rem;
-    color: #1f2937;
+    color: var(--color-gray-800);
     font-weight: 800;
 }
 
 .branchInfo p {
     margin: 6px 0 0 0;
     font-size: 0.9rem;
-    color: #475569;
+    color: var(--color-gray-250);
 }
 
 .barberList {
@@ -52,10 +52,10 @@
 }
 
 .barberItem {
-    background-color: #f0f4f8;
-    border: 1px solid #e2e8f0;
+    background-color: var(--color-surface-light-1);
+    border: 1px solid var(--color-gray-100);
     border-radius: 8px;
-    padding: 12px;
+    padding: var(--space-3);
     margin-bottom: 10px;
     display: flex;
     flex-direction: column;
@@ -65,35 +65,35 @@
 
 .barberItem:hover {
     transform: translateY(-6px) scale(1.03);
-    box-shadow: 0 12px 32px rgba(43, 108, 176, 0.18), 0 2px 8px rgba(0, 0, 0, 0.08);
-    background-color: #e3eafc;
-    border-color: #2b6cb0;
+    box-shadow: 0 12px 32px rgba(var(--color-primary-rgb), 0.18), 0 2px 8px var(--shadow-sm);
+    background-color: var(--color-surface-light-3);
+    border-color: var(--color-primary);
 }
 
 .selected {
     transform: translateY(-6px) scale(1.03);
-    box-shadow: 0 12px 32px rgba(43, 108, 176, 0.18), 0 2px 8px rgba(0, 0, 0, 0.08);
-    background-color: #e3eafc;
-    border-color: #2b6cb0;
+    box-shadow: 0 12px 32px rgba(var(--color-primary-rgb), 0.18), 0 2px 8px var(--shadow-sm);
+    background-color: var(--color-surface-light-3);
+    border-color: var(--color-primary);
 }
 
 .barberItem:not(.selected):hover {
     transform: none;
     box-shadow: none;
-    background-color: #f0f4f8;
-    border: 1px solid #e2e8f0;
+    background-color: var(--color-surface-light-1);
+    border: 1px solid var(--color-gray-100);
     cursor: default;
 }
 
 .barberName {
     font-size: 1.1rem;
     font-weight: 700;
-    color: #2d3748;
+    color: var(--color-gray-700);
 }
 
 .barberPhone {
     font-size: 0.9rem;
-    color: #4a5568;
+    color: var(--color-gray-450);
 }
 
 .inlineActions {
@@ -102,7 +102,7 @@
     gap: 0.7rem;
     margin-top: 0.9rem;
     padding-top: 0.9rem;
-    border-top: 1px solid #d7e1ee;
+    border-top: 1px solid var(--color-surface-light-7);
 }
 
 .inlineButton {
@@ -111,16 +111,16 @@
 
 .emptyState {
     text-align: center;
-    padding: 30px;
-    color: #718096;
+    padding: var(--space-7);
+    color: var(--color-gray-400);
     font-size: 1rem;
 }
 
 @media (min-width: 769px) {
     .barbersContainer {
         max-width: 800px;
-        margin: 40px auto;
-        padding: 30px;
+        margin: var(--space-8) auto;
+        padding: var(--space-7);
     }
 
     .cardsRow {
@@ -135,13 +135,13 @@
     }
 
     .barberItem {
-        padding: 20px;
-        gap: 8px;
+        padding: var(--space-5);
+        gap: var(--space-2);
         margin-bottom: 15px;
     }
 
     .barberName {
-        padding: 40px;
+        padding: var(--space-8);
         font-size: 1.1rem;
     }
 
@@ -173,25 +173,25 @@
     font-size: 1rem;
     border-radius: 10px;
     border: none;
-    background-color: #2b6cb0;
-    color: #fff;
+    background-color: var(--color-primary);
+    color: var(--color-white);
     font-weight: 700;
     cursor: pointer;
-    box-shadow: 0 6px 15px rgba(43, 108, 176, 0.4);
+    box-shadow: 0 6px 15px rgba(var(--color-primary-rgb), 0.4);
     transition: background 0.2s, transform 0.2s, box-shadow 0.2s;
     letter-spacing: 0.5px;
     outline: none;
 }
 
 .backButton:hover:not(:disabled) {
-    background: #0056b3;
+    background: var(--color-blue-bright-2);
     transform: translateY(-2px);
-    box-shadow: 0 4px 12px rgba(0, 123, 255, 0.3);
+    box-shadow: 0 4px 12px rgba(var(--color-blue-bright-rgb), 0.3);
 }
 
 .backButton:disabled {
-    background: #ccc;
-    color: #666;
+    background: var(--color-gray-60);
+    color: var(--color-gray-500);
     cursor: not-allowed;
     transform: none;
     box-shadow: none;

--- a/src/FRONT/views/components/Client/branches.module.css
+++ b/src/FRONT/views/components/Client/branches.module.css
@@ -5,13 +5,13 @@
   gap: 0.8rem;
   margin-top: 0.9rem;
   padding-top: 0.9rem;
-  border-top: 1px solid #d7e1ee;
+  border-top: 1px solid var(--color-surface-light-7);
 }
 
 .inlineOptionsTitle {
   font-size: 0.95rem;
   font-weight: 600;
-  color: #2d3748;
+  color: var(--color-gray-700);
 }
 
 .inlineOptionButtons {
@@ -29,11 +29,11 @@
   font-size: 1rem;
   border-radius: 10px;
   border: none;
-  background-color: #2b6cb0;
-  color: #fff;
+  background-color: var(--color-primary);
+  color: var(--color-white);
   font-weight: 700;
   cursor: pointer;
-  box-shadow: 0 6px 15px rgba(43, 108, 176, 0.4);
+  box-shadow: 0 6px 15px rgba(var(--color-primary-rgb), 0.4);
   transition:
     background 0.2s,
     transform 0.2s,
@@ -44,11 +44,11 @@
 
 .branchesContainer {
   max-width: 100%;
-  margin: 20px 0;
+  margin: var(--space-5) 0;
   padding: 15px;
-  background-color: #ffffff;
-  border-radius: 12px;
-  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.08);
+  background-color: var(--color-white);
+  border-radius: var(--radius-md);
+  box-shadow: 0 10px 25px var(--shadow-sm);
   animation: fadeIn 0.5s ease-out;
   display: flex;
   flex-direction: column;
@@ -62,10 +62,10 @@
 }
 
 .branchItem {
-  background-color: #f0f4f8;
-  border: 1px solid #e2e8f0;
+  background-color: var(--color-surface-light-1);
+  border: 1px solid var(--color-gray-100);
   border-radius: 8px;
-  padding: 12px;
+  padding: var(--space-3);
   margin-bottom: 10px;
   display: flex;
   flex-direction: column;
@@ -78,10 +78,10 @@
 .branchItem:hover {
   transform: translateY(-6px) scale(1.03);
   box-shadow:
-    0 12px 32px rgba(43, 108, 176, 0.18),
-    0 2px 8px rgba(0, 0, 0, 0.08);
-  background-color: #e3eafc;
-  border-color: #2b6cb0;
+    0 12px 32px rgba(var(--color-primary-rgb), 0.18),
+    0 2px 8px var(--shadow-sm);
+  background-color: var(--color-surface-light-3);
+  border-color: var(--color-primary);
 }
 
 /* When an element was recently deselected, disable hover to prevent
@@ -89,8 +89,8 @@
 .branchItem:not(.branchItemSelected):hover {
   transform: none;
   box-shadow: none;
-  background-color: #f0f4f8;
-  border: 1px solid #e2e8f0;
+  background-color: var(--color-surface-light-1);
+  border: 1px solid var(--color-gray-100);
   cursor: default;
 }
 
@@ -98,10 +98,10 @@
 .branchItemSelected {
   transform: translateY(-6px) scale(1.03);
   box-shadow:
-    0 12px 32px rgba(43, 108, 176, 0.18),
-    0 2px 8px rgba(0, 0, 0, 0.08);
-  background-color: #e3eafc;
-  border-color: #2b6cb0;
+    0 12px 32px rgba(var(--color-primary-rgb), 0.18),
+    0 2px 8px var(--shadow-sm);
+  background-color: var(--color-surface-light-3);
+  border-color: var(--color-primary);
 }
 
 /* Animations/transitions for state entry and exit */
@@ -117,12 +117,12 @@
 .branchName {
   font-size: 1.1rem;
   font-weight: 700;
-  color: #2d3748;
+  color: var(--color-gray-700);
 }
 
 .branchAddress {
   font-size: 0.95rem;
-  color: #718096;
+  color: var(--color-gray-400);
   font-weight: 500;
 }
 
@@ -149,16 +149,16 @@
   .optionButton {
     padding: 1.2rem 3rem;
     font-size: 1.25rem;
-    border-radius: 12px;
+    border-radius: var(--radius-md);
   }
   .branchesContainer {
     max-width: 800px;
-    margin: 40px auto;
-    padding: 30px;
+    margin: var(--space-8) auto;
+    padding: var(--space-7);
   }
   .branchItem {
-    padding: 20px;
-    gap: 8px;
+    padding: var(--space-5);
+    gap: var(--space-2);
     margin-bottom: 15px;
   }
   .branchName {

--- a/src/FRONT/views/components/Client/clientAppointments.module.css
+++ b/src/FRONT/views/components/Client/clientAppointments.module.css
@@ -1,70 +1,70 @@
 
 .successMessage {
-  background-color: #c6f6d5;
-  color: #22543d;
-  padding: 10px 12px;
+  background-color: var(--color-success-bg);
+  color: var(--color-success-dark);
+  padding: 10px var(--space-3);
   border-radius: 8px;
   margin-bottom: 15px;
-  border-left: 4px solid #38a169;
+  border-left: 4px solid var(--color-success);
   font-size: 1rem;
   text-align: center;
 }
 .reserveButton {
   margin-top: 10px;
   padding: 10px 18px;
-  background-color: #2b6cb0;
-  color: #fff;
+  background-color: var(--color-primary);
+  color: var(--color-white);
   border: none;
   border-radius: 8px;
   font-size: 0.95rem;
   font-weight: 600;
   cursor: pointer;
-  box-shadow: 0 2px 8px rgba(43, 108, 176, 0.15);
+  box-shadow: 0 2px 8px rgba(var(--color-primary-rgb), 0.15);
   transition:
     background 0.2s,
     transform 0.2s;
 }
 
 .reserveButton:hover {
-  background-color: #2c5282;
+  background-color: var(--color-blue-dark);
   transform: translateY(-2px);
 }
 
 .barberInfo {
   width: 100%;
-  background: #f0f4f8;
-  border: 1px solid #e2e8f0;
+  background: var(--color-surface-light-1);
+  border: 1px solid var(--color-gray-100);
   border-radius: 8px;
   padding: 1px; /* slightly reduced padding */
   margin-bottom: 10px; /* reduce space below barber info */
-  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.04);
+  box-shadow: 0 1px 6px rgba(var(--shadow-color), 0.04);
   position: sticky;
   top: calc(
     --header-height,
     64px
   ); /* small offset so sticky card isn't flush */
   z-index: 40;
-  background: #f7fafc; /* ensure solid background when sticky */
+  background: var(--color-surface-light-21); /* ensure solid background when sticky */
 }
 
 .barberInfo h3 {
   margin-top: 0;
-  margin-bottom: 8px;
+  margin-bottom: var(--space-2);
   font-size: 1rem;
-  color: #2d3748;
+  color: var(--color-gray-700);
 }
 .barberInfo div {
   font-size: 0.95rem;
-  color: #4a5568;
+  color: var(--color-gray-450);
   margin-bottom: 5px;
 }
 .appointmentsContainer {
   max-width: 100%;
-  margin: 12px 0; /* reduce vertical margins */
-  padding: 12px; /* slightly smaller padding */
-  background-color: #ffffff;
+  margin: var(--space-3) 0; /* reduce vertical margins */
+  padding: var(--space-3); /* slightly smaller padding */
+  background-color: var(--color-white);
   border-radius: 10px;
-  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.06);
+  box-shadow: 0 8px 18px rgba(var(--shadow-color), 0.06);
   animation: fadeIn 0.35s ease-out;
   display: flex;
   flex-direction: column;
@@ -78,7 +78,7 @@
   flex-wrap: wrap;
   justify-content: center;
   align-items: center;
-  margin-top: 16px;
+  margin-top: var(--space-4);
 }
 
 .appointmentList {
@@ -98,10 +98,10 @@
 
 /* Mobile-first: stack card content vertically */
 .hourCard {
-  background: #ffffff;
-  border: 1px solid #e6eef8;
+  background: var(--color-white);
+  border: 1px solid var(--color-surface-light-9);
   border-radius: 10px;
-  padding: 12px 14px;
+  padding: var(--space-3) 14px;
   display: flex;
   flex-direction: column;
   gap: 10px;
@@ -112,28 +112,28 @@
 
 .hourCard:hover {
   transform: translateY(-4px);
-  box-shadow: 0 8px 18px rgba(15, 45, 75, 0.06);
+  box-shadow: 0 8px 18px rgba(var(--color-navy-light-rgb), 0.06);
 }
 
 .hourAvailable {
-  border-left: 4px solid #48bb78;
+  border-left: 4px solid var(--color-success-bright);
 }
 
 .hourBooked {
   opacity: 0.7;
-  border-left: 4px solid #f56565;
-  background: #fff5f5;
+  border-left: 4px solid var(--color-danger-alt-3);
+  background: var(--color-danger-bg-2);
 }
 
 .hourTime {
   font-size: 1rem;
   font-weight: 700;
-  color: #2d3748;
+  color: var(--color-gray-700);
 }
 
 .hourMeta {
   font-size: 0.9rem;
-  color: #718096;
+  color: var(--color-gray-400);
 }
 
 /* Mobile-first: ensure the right-side area stacks under the time and shows status above the button */
@@ -143,12 +143,12 @@
   flex-direction: column;
   justify-content: flex-start;
   align-items: flex-start;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .reserveButton {
   width: 100%;
-  padding: 8px 12px;
+  padding: var(--space-2) var(--space-3);
   font-size: 0.9rem;
   margin-top: 0;
 }
@@ -158,14 +158,14 @@
 }
 
 .appointmentItem {
-  background-color: #f0f4f8;
-  border: 1px solid #e2e8f0;
+  background-color: var(--color-surface-light-1);
+  border: 1px solid var(--color-gray-100);
   border-radius: 8px;
-  padding: 16px;
-  margin-bottom: 12px;
+  padding: var(--space-4);
+  margin-bottom: var(--space-3);
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: var(--space-3);
   transition:
     transform 0.2s ease,
     box-shadow 0.2s ease;
@@ -173,13 +173,13 @@
 
 .appointmentItem:hover {
   transform: translateY(-3px);
-  box-shadow: 0 6px 15px rgba(0, 0, 0, 0.05);
+  box-shadow: 0 6px 15px rgba(var(--shadow-color), 0.05);
 }
 
 .appointmentDetails {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--space-2);
 }
 .appointmentActions {
   display: flex;
@@ -187,30 +187,30 @@
   flex-wrap: wrap;
   justify-content: center;
   align-items: center;
-  margin-top: 16px;
+  margin-top: var(--space-4);
 }
 
 .detailRow {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   font-size: 0.95rem;
 }
 
 .detailLabel {
   font-weight: 600;
-  color: #4a5568;
+  color: var(--color-gray-450);
   min-width: 100px;
 }
 
 .detailValue {
-  color: #2d3748;
+  color: var(--color-gray-700);
 }
 
 .statusBadge {
-  color: white;
-  padding: 4px 12px;
-  border-radius: 12px;
+  color: var(--color-white);
+  padding: var(--space-1) var(--space-3);
+  border-radius: var(--radius-md);
   font-size: 0.85rem;
   font-weight: 600;
 }
@@ -218,43 +218,43 @@
 /*Esto se repite en tres archivos, se puede unificar en un solo archivo de estilos compartido.*/
 
 .statusProgramado {
-  background-color: #4299e1; /*  blue - appointment scheduled and active */
+  background-color: var(--color-primary-hover); /*  blue - appointment scheduled and active */
 }
 
 .statusCancelado {
-  background-color: #e53e3e; /* red - canceled by the client  */
+  background-color: var(--color-danger-bright); /* red - canceled by the client  */
 }
 
 .statusCobrado {
-  background-color: #48bb78; /*  green - done and paid */
+  background-color: var(--color-success-bright); /*  green - done and paid */
 }
 
 .statusSinCobrar {
-  background-color: #ed8936; /* orange - done but not paid */
+  background-color: var(--color-warning-alt-2); /* orange - done but not paid */
 }
 
 .statusNoAsistido {
-  background-color: #718096; /* gray - no-show */
+  background-color: var(--color-gray-400); /* gray - no-show */
 }
 
 .deleteButton {
   width: 100%;
   padding: 10px;
-  background-color: #e53e3e;
-  color: white;
+  background-color: var(--color-danger-bright);
+  color: var(--color-white);
   border: none;
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   font-weight: 600;
   cursor: pointer;
   transition: background-color 0.2s;
 }
 
 .deleteButton:hover:not(:disabled) {
-  background-color: #c53030;
+  background-color: var(--color-danger);
 }
 
 .deleteButton:disabled {
-  background-color: #cbd5e0;
+  background-color: var(--color-gray-150);
   cursor: not-allowed;
   opacity: 0.6;
 }
@@ -262,10 +262,10 @@
 .invoiceButton {
   width: 100%;
   padding: 10px;
-  background-color: #2b6cb0;
-  color: white;
+  background-color: var(--color-primary);
+  color: var(--color-white);
   border: none;
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   font-weight: 600;
   cursor: pointer;
   transition:
@@ -274,41 +274,41 @@
 }
 
 .invoiceButton:hover {
-  background-color: #2c5282;
+  background-color: var(--color-blue-dark);
   transform: translateY(-2px);
 }
 
 .appointmentUnavailable {
-  background-color: #fed7d7;
-  border-color: #e53e3e;
+  background-color: var(--color-danger-bg);
+  border-color: var(--color-danger-bright);
 }
 
 .appointmentDate {
   font-size: 1rem;
   font-weight: 600;
-  color: #2d3748;
+  color: var(--color-gray-700);
 }
 
 .appointmentHour {
   font-size: 0.95rem;
-  color: #718096;
+  color: var(--color-gray-400);
   font-weight: 500;
 }
 
 .appointmentStatus {
   font-size: 0.95rem;
   font-weight: 600;
-  color: #38a169;
+  color: var(--color-success);
 }
 
 .appointmentUnavailable .appointmentStatus {
-  color: #e53e3e;
+  color: var(--color-danger-bright);
 }
 
 .emptyState {
   text-align: center;
-  padding: 30px;
-  color: #718096;
+  padding: var(--space-7);
+  color: var(--color-gray-400);
   font-size: 1rem;
 }
 
@@ -318,64 +318,64 @@
 }
 
 .modalTitle {
-  margin: 0 0 16px 0;
-  font-size: 18px;
+  margin: 0 0 var(--space-4) 0;
+  font-size: var(--font-size-lg);
   font-weight: 600;
 }
 
 .modalButtons {
   display: flex;
-  gap: 12px;
+  gap: var(--space-3);
   justify-content: center;
   align-items: center;
 }
 
 .buttonCancel {
-  background: #718096;
-  color: white;
+  background: var(--color-gray-400);
+  color: var(--color-white);
   border: none;
-  padding: 12px 24px;
+  padding: var(--space-3) var(--space-6);
   border-radius: 8px;
   cursor: pointer;
-  font-size: 16px;
+  font-size: var(--font-size-md);
   font-weight: 600;
   min-width: 120px;
   transition: all 0.2s ease;
 }
 
 .buttonCancel:hover {
-  background: #4a5568;
+  background: var(--color-gray-450);
 }
 
 .buttonConfirm {
-  background: #e53e3e;
-  color: white;
+  background: var(--color-danger-bright);
+  color: var(--color-white);
   border: none;
-  padding: 12px 24px;
+  padding: var(--space-3) var(--space-6);
   border-radius: 8px;
   cursor: pointer;
-  font-size: 16px;
+  font-size: var(--font-size-md);
   font-weight: 600;
   min-width: 120px;
   transition: all 0.2s ease;
 }
 
 .buttonConfirm:hover {
-  background: #c53030;
+  background: var(--color-danger);
 }
 
 .pagination {
   display: flex;
-  gap: 8px;
+  gap: var(--space-2);
   justify-content: center;
-  margin-top: 16px;
+  margin-top: var(--space-4);
 }
 
 .pageButton {
   padding: 6px 10px;
-  border-radius: 6px;
-  border: 1px solid #e2e8f0;
-  background: #fff;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-gray-100);
+  background: var(--color-white);
   cursor: pointer;
 }
 
@@ -385,29 +385,29 @@
 }
 
 .pageActive {
-  background: #2b6cb0;
-  color: #fff;
-  border-color: #2b6cb0;
+  background: var(--color-primary);
+  color: var(--color-white);
+  border-color: var(--color-primary);
 }
 
 .summary {
   width: 100%;
   text-align: center;
-  margin: 10px 0 16px 0;
-  color: #4a5568;
+  margin: 10px 0 var(--space-4) 0;
+  color: var(--color-gray-450);
   font-weight: 600;
 }
 /* DESKTOP */
 @media (min-width: 769px) {
   .appointmentsContainer {
     max-width: 600px;
-    margin: 40px auto;
-    padding: 30px;
+    margin: var(--space-8) auto;
+    padding: var(--space-7);
   }
 
   .appointmentItem {
-    padding: 20px;
-    gap: 12px;
+    padding: var(--space-5);
+    gap: var(--space-3);
     margin-bottom: 15px;
   }
 
@@ -425,18 +425,18 @@
 
   .deleteButton {
     width: auto;
-    padding: 10px 24px;
+    padding: 10px var(--space-6);
     align-self: flex-end;
   }
 
   .invoiceButton {
     width: auto;
-    padding: 10px 24px;
+    padding: 10px var(--space-6);
     align-self: flex-end;
   }
   .barberInfo {
     padding: 18px;
-    margin-bottom: 24px;
+    margin-bottom: var(--space-6);
   }
   .barberInfo h3 {
     font-size: 1.2rem;
@@ -447,16 +447,16 @@
     margin-bottom: 6px;
   }
   .emptyState {
-    padding: 40px;
+    padding: var(--space-8);
     font-size: 1.1rem;
   }
   .hoursGrid {
     grid-template-columns: repeat(4, 1fr);
-    gap: 16px;
+    gap: var(--space-4);
   }
 
   .hourCard {
-    padding: 16px 18px;
+    padding: var(--space-4) 18px;
     flex-direction: row;
     align-items: center;
     justify-content: space-between;
@@ -493,7 +493,7 @@
     margin-bottom: 12px !important;
     z-index: 2;
     position: relative;
-    background: #f7fafc; /* slightly lighter on mobile */
+    background: var(--color-surface-light-21); /* slightly lighter on mobile */
   }
 }
 
@@ -511,17 +511,17 @@
 
 .filtersContainer {
   display: flex;
-  gap: 12px;
-  margin-bottom: 16px;
+  gap: var(--space-3);
+  margin-bottom: var(--space-4);
   flex-wrap: wrap;
 }
 
 .filterSelect {
-  padding: 8px 12px;
-  border-radius: 6px;
-  border: 1px solid #e2e8f0;
-  background-color: #f7fafc;
-  color: #2d3748;
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-gray-100);
+  background-color: var(--color-surface-light-21);
+  color: var(--color-gray-700);
   font-size: 0.95rem;
   font-weight: 500;
   cursor: pointer;
@@ -530,12 +530,12 @@
 }
 
 .filterSelect:focus {
-  border-color: #4299e1;
+  border-color: var(--color-primary-hover);
 }
 
 @media (min-width: 769px) {
   .filtersContainer {
-    margin-bottom: 24px;
+    margin-bottom: var(--space-6);
   }
   .detailsActionButtons .button {
     width: 240px;

--- a/src/FRONT/views/components/Client/home/home.module.css
+++ b/src/FRONT/views/components/Client/home/home.module.css
@@ -1,7 +1,7 @@
 body {
   font-family: "Inter", sans-serif;
-  background-color: #f8f8f8;
-  color: #333;
+  background-color: var(--color-surface-light-18);
+  color: var(--color-gray-600);
   margin: 0;
   padding: 10px;
   line-height: 1.6;
@@ -11,23 +11,23 @@ body {
 
 .homeContainer {
   max-width: 1000px;
-  margin: 20px auto;
-  padding: 16px;
+  margin: var(--space-5) auto;
+  padding: var(--space-4);
   display: grid;
-  gap: 24px;
+  gap: var(--space-6);
   animation: fadeIn 0.5s ease-out;
 }
 
 .welcomeSection {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 .welcomeHeader {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: var(--space-3);
   align-items: flex-start;
 }
 
@@ -47,7 +47,7 @@ body {
 
 .welcomeSubtitle {
   margin: 0;
-  color: #8a8a8a;
+  color: var(--color-gray-40);
 }
 
 .primaryButton {
@@ -67,15 +67,15 @@ body {
     transform 0.2s ease,
     box-shadow 0.3s ease;
   text-decoration: none;
-  background-color: #2b6cb0;
-  color: #ffffff;
-  box-shadow: 0 6px 15px rgba(43, 108, 176, 0.4);
+  background-color: var(--color-primary);
+  color: var(--color-white);
+  box-shadow: 0 6px 15px rgba(var(--color-primary-rgb), 0.4);
 }
 
 .primaryButton:hover:not(:disabled) {
-  background-color: #2c5282;
+  background-color: var(--color-blue-dark);
   transform: translateY(-3px);
-  box-shadow: 0 8px 20px rgba(43, 108, 176, 0.5);
+  box-shadow: 0 8px 20px rgba(var(--color-primary-rgb), 0.5);
 }
 
 .buttonIcon {
@@ -84,33 +84,33 @@ body {
 
 .nextTurnoSection {
   display: grid;
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 .sectionHeader {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 .sectionTitleLight {
   margin: 0;
   font-size: 1.25rem;
-  color: #1f2937;
+  color: var(--color-gray-800);
 }
 
 .sectionTitle {
   margin: 0;
   font-size: 1.25rem;
-  color: #1f2937;
+  color: var(--color-gray-800);
 }
 
 .linkButton {
-  background: #e6f0ff;
-  border: 1px solid #c8dcff;
-  color: #2b6cb0;
-  border-radius: 999px;
+  background: var(--color-surface-light-8);
+  border: 1px solid var(--color-surface-light-13);
+  color: var(--color-primary);
+  border-radius: var(--radius-full);
   padding: 0.4rem 0.9rem;
   font-weight: 600;
   cursor: pointer;
@@ -120,19 +120,19 @@ body {
 }
 
 .linkButton:hover {
-  background: #d7e7ff;
+  background: var(--color-surface-light-12);
   transform: translateY(-1px);
 }
 
 .turnoCard {
-  background-color: #f0f4f8;
-  border: 1px solid #e2e8f0;
+  background-color: var(--color-surface-light-1);
+  border: 1px solid var(--color-gray-100);
   border-radius: 8px;
-  padding: 16px;
+  padding: var(--space-4);
   margin-bottom: 0;
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: var(--space-3);
   transition:
     transform 0.2s ease,
     box-shadow 0.2s ease;
@@ -140,13 +140,13 @@ body {
 
 .turnoCard:hover {
   transform: translateY(-3px);
-  box-shadow: 0 6px 15px rgba(0, 0, 0, 0.05);
+  box-shadow: 0 6px 15px rgba(var(--shadow-color), 0.05);
 }
 
 .turnoCardContent {
   display: flex;
   flex-wrap: wrap;
-  gap: 16px;
+  gap: var(--space-4);
   align-items: center;
 }
 
@@ -154,14 +154,14 @@ body {
   width: 88px;
   min-width: 88px;
   height: 88px;
-  border-radius: 12px;
-  background-color: #ffffff;
-  border: 1px solid #e2e8f0;
+  border-radius: var(--radius-md);
+  background-color: var(--color-white);
+  border: 1px solid var(--color-gray-100);
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  box-shadow: 0 4px 12px rgba(15, 23, 42, 0.06);
+  box-shadow: 0 4px 12px rgba(var(--color-slate-rgb), 0.06);
 }
 
 .turnoDateMonth {
@@ -169,13 +169,13 @@ body {
   font-weight: 700;
   letter-spacing: 0.12em;
   text-transform: uppercase;
-  color: #718096;
+  color: var(--color-gray-400);
 }
 
 .turnoDateDay {
   font-size: 1.9rem;
   font-weight: 700;
-  color: #1f2937;
+  color: var(--color-gray-800);
   line-height: 1;
 }
 
@@ -190,55 +190,55 @@ body {
 .turnoInfoRow {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   font-size: 0.95rem;
-  color: #2d3748;
+  color: var(--color-gray-700);
 }
 
 .turnoInfoLabel {
   font-weight: 600;
-  color: #4a5568;
+  color: var(--color-gray-450);
   min-width: 80px;
 }
 
 .turnoInfoIcon {
   font-size: 1rem;
-  color: #2b6cb0;
+  color: var(--color-primary);
 }
 
 .turnoInfoText {
   font-weight: 600;
-  color: #2d3748;
+  color: var(--color-gray-700);
 }
 
 .turnoRow {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   font-size: 0.95rem;
 }
 
 .turnoLabel {
   font-weight: 600;
-  color: #4a5568;
+  color: var(--color-gray-450);
   min-width: 100px;
 }
 
 .turnoValue {
-  color: #2d3748;
+  color: var(--color-gray-700);
 }
 
 .cardEmpty {
   margin: 0;
-  color: #6b7280;
+  color: var(--color-gray-300);
 }
 
 .turnoActions {
   display: flex;
   flex-direction: column;
-  gap: 12px;
-  margin-top: 4px;
+  gap: var(--space-3);
+  margin-top: var(--space-1);
   width: 100%;
   align-items: flex-end;
 }
@@ -247,7 +247,7 @@ body {
   width: 100%;
   padding: 10px;
   border: none;
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   font-weight: 600;
   cursor: pointer;
   transition:
@@ -256,7 +256,7 @@ body {
 }
 
 .turnoButton:disabled {
-  background-color: #cbd5e0;
+  background-color: var(--color-gray-150);
   cursor: not-allowed;
   opacity: 0.7;
   transform: none;
@@ -264,16 +264,16 @@ body {
 
 .turnoButtonSubtle {
   background-color: transparent;
-  color: #718096;
-  border: 1px solid #c53030;
-  padding: 8px 14px;
+  color: var(--color-gray-400);
+  border: 1px solid var(--color-danger);
+  padding: var(--space-2) 14px;
   font-size: 0.9rem;
 }
 
 .turnoButtonSubtle:hover:not(:disabled) {
-  background-color: #fff5f5;
-  border-color: #fed7d7;
-  color: #c53030;
+  background-color: var(--color-danger-bg-2);
+  border-color: var(--color-danger-bg);
+  color: var(--color-danger);
   transform: translateY(-1px);
 }
 
@@ -282,176 +282,176 @@ body {
 }
 
 .modalTitle {
-  margin: 0 0 16px 0;
-  font-size: 18px;
+  margin: 0 0 var(--space-4) 0;
+  font-size: var(--font-size-lg);
   font-weight: 600;
 }
 
 .modalButtons {
   display: flex;
-  gap: 12px;
+  gap: var(--space-3);
   justify-content: center;
   align-items: center;
 }
 
 .buttonCancel {
-  background: #718096;
-  color: white;
+  background: var(--color-gray-400);
+  color: var(--color-white);
   border: none;
-  padding: 12px 24px;
+  padding: var(--space-3) var(--space-6);
   border-radius: 8px;
   cursor: pointer;
-  font-size: 16px;
+  font-size: var(--font-size-md);
   font-weight: 600;
   min-width: 120px;
   transition: all 0.2s ease;
 }
 
 .buttonCancel:hover {
-  background: #4a5568;
+  background: var(--color-gray-450);
 }
 
 .buttonConfirm {
-  background: #e53e3e;
-  color: white;
+  background: var(--color-danger-bright);
+  color: var(--color-white);
   border: none;
-  padding: 12px 24px;
+  padding: var(--space-3) var(--space-6);
   border-radius: 8px;
   cursor: pointer;
-  font-size: 16px;
+  font-size: var(--font-size-md);
   font-weight: 600;
   min-width: 120px;
   transition: all 0.2s ease;
 }
 
 .buttonConfirm:hover {
-  background: #c53030;
+  background: var(--color-danger);
 }
 
 .loyaltySection {
   display: grid;
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 .badge {
-  background-color: #e6f0ff;
-  color: #2b6cb0;
+  background-color: var(--color-surface-light-8);
+  color: var(--color-primary);
   font-weight: 600;
   padding: 0.3rem 0.8rem;
-  border-radius: 999px;
+  border-radius: var(--radius-full);
   font-size: 0.85rem;
 }
 
 .loyaltyCard {
-  margin-top: 12px;
-  background-color: #f8fafc;
-  border-radius: 12px;
-  padding: 16px;
-  border: 1px solid #e2e8f0;
+  margin-top: var(--space-3);
+  background-color: var(--color-gray-25);
+  border-radius: var(--radius-md);
+  padding: var(--space-4);
+  border: 1px solid var(--color-gray-100);
 }
 
 .loyaltyDiscount {
-  margin: 0 0 8px 0;
+  margin: 0 0 var(--space-2) 0;
   font-weight: 600;
-  color: #1f2937;
+  color: var(--color-gray-800);
 }
 
 .loyaltyRemaining {
   margin: 0;
-  color: #4a5568;
+  color: var(--color-gray-450);
   font-size: 0.95rem;
 }
 
 .discountProgress {
-  margin-top: 12px;
-  padding: 12px;
-  background: #ffffff;
-  border-radius: 12px;
-  border: 1px solid #e2e8f0;
-  box-shadow: 0 6px 16px rgba(15, 23, 42, 0.08);
+  margin-top: var(--space-3);
+  padding: var(--space-3);
+  background: var(--color-white);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-gray-100);
+  box-shadow: 0 6px 16px rgba(var(--color-slate-rgb), 0.08);
 }
 
 .progressInfo {
   display: flex;
   justify-content: space-between;
   font-weight: 600;
-  color: #1f2937;
+  color: var(--color-gray-800);
 }
 
 .progressBar {
   margin: 10px 0 6px 0;
   height: 14px;
-  background: linear-gradient(90deg, #e2e8f0, #edf2f7);
-  border-radius: 999px;
+  background: linear-gradient(90deg, var(--color-gray-100), var(--color-surface-light-22));
+  border-radius: var(--radius-full);
   overflow: hidden;
-  box-shadow: inset 0 1px 4px rgba(15, 23, 42, 0.12);
+  box-shadow: inset 0 1px 4px rgba(var(--color-slate-rgb), 0.12);
 }
 
 .progressFill {
   height: 100%;
-  background: linear-gradient(90deg, #2b6cb0, #38b2ac);
+  background: linear-gradient(90deg, var(--color-primary), var(--color-success-bright-2));
   width: 0;
   transition: width 0.35s ease;
-  box-shadow: 0 4px 10px rgba(43, 108, 176, 0.35);
+  box-shadow: 0 4px 10px rgba(var(--color-primary-rgb), 0.35);
 }
 
 .discountContent {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .discountTurns {
   margin: 0;
   font-size: 1.2rem;
   font-weight: 700;
-  color: #1f2937;
+  color: var(--color-gray-800);
 }
 
 .discountTurnsCount {
-  color: #000000;
+  color: var(--color-black);
   font-size: 1.4rem;
 }
 
 .discountDescription {
   margin: 0;
-  color: #6b7280;
+  color: var(--color-gray-300);
   font-size: 0.95rem;
 }
 
 .progressPercentage {
-  margin: 8px 0 0 0;
+  margin: var(--space-2) 0 0 0;
   font-size: 0.9rem;
   font-weight: 600;
-  color: #2b6cb0;
+  color: var(--color-primary);
 }
 
 .progressBar {
-  margin-top: 16px;
+  margin-top: var(--space-4);
   height: 14px;
-  background: linear-gradient(90deg, #e2e8f0, #edf2f7);
-  border-radius: 999px;
+  background: linear-gradient(90deg, var(--color-gray-100), var(--color-surface-light-22));
+  border-radius: var(--radius-full);
   overflow: hidden;
-  box-shadow: inset 0 1px 4px rgba(15, 23, 42, 0.12);
+  box-shadow: inset 0 1px 4px rgba(var(--color-slate-rgb), 0.12);
 }
 
 .progressMeta {
   display: flex;
   flex-wrap: wrap;
-  gap: 12px;
+  gap: var(--space-3);
   font-size: 0.85rem;
-  color: #64748b;
+  color: var(--color-gray-350);
 }
 
 .loyaltyHint {
   margin: 10px 0 0;
   font-size: 0.9rem;
-  color: #475569;
+  color: var(--color-gray-250);
 }
 
 .loyaltyMessage {
   margin: 0;
-  color: #475569;
+  color: var(--color-gray-250);
 }
 
 @keyframes fadeIn {
@@ -469,7 +469,7 @@ body {
 @media (min-width: 769px) {
   .homeContainer {
     margin: 50px auto;
-    padding: 24px;
+    padding: var(--space-6);
     gap: 32px;
   }
   .welcomeTitle {
@@ -488,6 +488,6 @@ body {
   }
   .turnoButton {
     width: auto;
-    padding: 8px 18px;
+    padding: var(--space-2) 18px;
   }
 }

--- a/src/FRONT/views/components/Client/profile/profile.module.css
+++ b/src/FRONT/views/components/Client/profile/profile.module.css
@@ -1,23 +1,23 @@
 .formContainer {
   width: 100%;
   margin: 0 auto;
-  padding: 12px;
-  background: white;
+  padding: var(--space-3);
+  background: var(--color-white);
   border-radius: 10px;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.08);
+  box-shadow: 0 2px 4px var(--shadow-sm);
 }
 
 .pageTitle {
   text-align: center;
-  color: #333;
+  color: var(--color-gray-600);
   margin-bottom: 18px;
   font-size: 1.3rem;
   font-weight: 600;
 }
 
 .clienteInfo {
-  background: #f8f9fa;
-  padding: 12px;
+  background: var(--color-surface-light-19);
+  padding: var(--space-3);
   border-radius: 8px;
   margin-bottom: 14px;
 }
@@ -25,41 +25,41 @@
 .clienteTitle {
   font-size: 1.1rem;
   font-weight: bold;
-  color: #2c3e50;
-  margin-bottom: 12px;
+  color: var(--color-gray-850);
+  margin-bottom: var(--space-3);
   text-align: center;
   padding-bottom: 6px;
-  border-bottom: 2px solid #3498db;
+  border-bottom: 2px solid var(--color-accent-blue);
 }
 
 .profileSection {
-  margin: 12px 0;
+  margin: var(--space-3) 0;
   padding: 14px;
-  background: #ffffff;
-  border-radius: 12px;
-  border: 1px solid #e3e9ef;
-  box-shadow: 0 6px 16px rgba(15, 23, 42, 0.06);
+  background: var(--color-white);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-surface-light-11);
+  box-shadow: 0 6px 16px rgba(var(--color-slate-rgb), 0.06);
 }
 
 .profileSection h3 {
-  margin: 0 0 12px 0;
-  color: #2c3e50;
+  margin: 0 0 var(--space-3) 0;
+  color: var(--color-gray-850);
   font-size: 1rem;
   font-weight: 600;
   padding-bottom: 6px;
-  border-bottom: 1px solid #e5eaf0;
+  border-bottom: 1px solid var(--color-surface-light-6);
 }
 
 .profileField {
-  margin: 8px 0;
-  padding: 8px 0;
+  margin: var(--space-2) 0;
+  padding: var(--space-2) 0;
   font-size: 15px;
-  color: #555;
+  color: var(--color-gray-30);
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  gap: 4px;
-  border-bottom: 1px dashed #e5eaf0;
+  gap: var(--space-1);
+  border-bottom: 1px dashed var(--color-surface-light-6);
 }
 
 .profileSection .profileField:last-of-type {
@@ -67,7 +67,7 @@
 }
 
 .profileField strong {
-  color: #2c3e50;
+  color: var(--color-gray-850);
   margin-bottom: 2px;
   min-width: 100px;
   font-weight: 600;
@@ -83,7 +83,7 @@
   display: flex;
   flex-direction: column;
   gap: 10px;
-  margin-top: 8px;
+  margin-top: var(--space-2);
   align-items: flex-start;
 }
 
@@ -91,10 +91,10 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  background-color: #3498db;
-  color: #fff;
-  border-radius: 6px;
-  padding: 10px 16px;
+  background-color: var(--color-accent-blue);
+  color: var(--color-white);
+  border-radius: var(--radius-sm);
+  padding: 10px var(--space-4);
   font-size: 0.95rem;
   font-weight: 600;
   text-decoration: none;
@@ -104,16 +104,16 @@
 }
 
 .actionLink:hover {
-  background-color: #2980b9;
+  background-color: var(--color-accent-teal);
   transform: translateY(-1px);
 }
 
 .editButton {
-  background-color: #3498db;
-  color: white;
+  background-color: var(--color-accent-blue);
+  color: var(--color-white);
   border: none;
   padding: 10px 0;
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   font-size: 15px;
   font-weight: 600;
   cursor: pointer;
@@ -121,14 +121,14 @@
 }
 
 .editButton:hover {
-  background-color: #2980b9;
+  background-color: var(--color-accent-teal);
   transform: translateY(-1px);
 }
 
 .emptyState {
   text-align: center;
-  padding: 24px;
-  color: #666;
+  padding: var(--space-6);
+  color: var(--color-gray-500);
   font-size: 15px;
 }
 
@@ -136,25 +136,25 @@
 @media (min-width: 768px) {
   .formContainer {
     max-width: 800px;
-    padding: 20px;
-    border-radius: 12px;
-    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+    padding: var(--space-5);
+    border-radius: var(--radius-md);
+    box-shadow: 0 4px 6px var(--shadow-md);
   }
   .pageTitle {
     font-size: 2rem;
-    margin-bottom: 30px;
+    margin-bottom: var(--space-7);
   }
   .clienteInfo {
-    padding: 20px;
-    margin-bottom: 20px;
+    padding: var(--space-5);
+    margin-bottom: var(--space-5);
   }
   .clienteTitle {
     font-size: 1.5rem;
-    margin-bottom: 20px;
+    margin-bottom: var(--space-5);
     padding-bottom: 10px;
   }
   .profileSection {
-    margin: 20px 0;
+    margin: var(--space-5) 0;
     padding: 18px;
   }
   .profileSection h3 {
@@ -162,11 +162,11 @@
     margin-bottom: 15px;
   }
   .profileField {
-    font-size: 16px;
+    font-size: var(--font-size-md);
     display: grid;
     grid-template-columns: 140px 1fr;
     align-items: start;
-    column-gap: 12px;
+    column-gap: var(--space-3);
     row-gap: 6px;
   }
   .profileField strong {
@@ -176,64 +176,64 @@
   }
   .actionButtons {
     flex-direction: row;
-    gap: 12px;
+    gap: var(--space-3);
     margin-top: 10px;
     align-items: center;
     justify-content: flex-start;
   }
   .editButton {
-    padding: 12px 24px;
-    font-size: 16px;
+    padding: var(--space-3) var(--space-6);
+    font-size: var(--font-size-md);
   }
   .editButton:hover {
     transform: translateY(-2px);
   }
   .emptyState {
-    padding: 40px;
-    font-size: 18px;
+    padding: var(--space-8);
+    font-size: var(--font-size-lg);
   }
 }
 
 .categoryDetails {
   margin-top: 0.5rem;
   padding: 1rem;
-  background-color: #f8f9fa;
+  background-color: var(--color-surface-light-19);
   border-radius: 8px;
-  border-left: 4px solid #007bff;
+  border-left: 4px solid var(--color-blue-bright);
 }
 
 .categoryDetails p {
   margin: 0.25rem 0;
   font-size: 0.9rem;
-  color: #666;
+  color: var(--color-gray-500);
 }
 
 .categoryDetails strong {
-  color: #333;
+  color: var(--color-gray-600);
 }
 
 .securityForm {
-  margin-top: 12px;
+  margin-top: var(--space-3);
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .securityLabel {
   font-size: 0.95rem;
   font-weight: 600;
-  color: #2c3e50;
+  color: var(--color-gray-850);
 }
 
 .securitySelect,
 .securityInput {
   width: 100%;
-  padding: 10px 12px;
+  padding: 10px var(--space-3);
   border-radius: 8px;
-  border: 1px solid #d5dce3;
-  background: #fff;
+  border: 1px solid var(--color-surface-light-26);
+  background: var(--color-white);
   font-size: 0.95rem;
-  color: #2c3e50;
+  color: var(--color-gray-850);
   transition:
     border-color 0.2s ease,
     box-shadow 0.2s ease;
@@ -242,21 +242,21 @@
 .securitySelect:focus,
 .securityInput:focus {
   outline: none;
-  border-color: #3498db;
-  box-shadow: 0 0 0 3px rgba(52, 152, 219, 0.15);
+  border-color: var(--color-accent-blue);
+  box-shadow: 0 0 0 3px rgba(var(--color-teal-rgb), 0.15);
 }
 
 .securityActions {
-  margin-top: 4px;
+  margin-top: var(--space-1);
   display: flex;
   justify-content: flex-start;
 }
 
 .securityButton {
-  background-color: #3498db;
-  color: #fff;
+  background-color: var(--color-accent-blue);
+  color: var(--color-white);
   border: none;
-  padding: 10px 16px;
+  padding: 10px var(--space-4);
   border-radius: 8px;
   font-size: 0.95rem;
   font-weight: 600;
@@ -272,7 +272,7 @@
 }
 
 .securityButton:hover:not(:disabled) {
-  background-color: #2980b9;
+  background-color: var(--color-accent-teal);
   transform: translateY(-1px);
 }
 
@@ -288,7 +288,7 @@
     font-size: 1rem;
   }
   .securityButton {
-    padding: 12px 20px;
+    padding: var(--space-3) var(--space-5);
     font-size: 1rem;
   }
 }

--- a/src/FRONT/views/components/Client/scheduleByBranch.module.css
+++ b/src/FRONT/views/components/Client/scheduleByBranch.module.css
@@ -7,12 +7,12 @@
 .selectedBarberInfo {
   width: 100%;
   text-align: center;
-  background: #f9f9f9;
-  border: 2px solid #ddd;
-  padding: 12px 16px;
+  background: var(--color-surface-light-17);
+  border: 2px solid var(--color-gray-75);
+  padding: var(--space-3) var(--space-4);
   border-radius: 10px;
   margin-bottom: 14px;
-  box-shadow: 0 6px 18px rgba(43, 108, 176, 0.04);
+  box-shadow: 0 6px 18px rgba(var(--color-primary-rgb), 0.04);
 }
 
 .infoRow {
@@ -28,7 +28,7 @@
 .selectedBarberInfo h4 {
   margin: 0;
   font-size: 1.05rem;
-  color: #1f2937;
+  color: var(--color-gray-800);
   font-weight: 800;
 }
 
@@ -36,7 +36,7 @@
 .selectedBarberInfo p {
   margin: 6px 0 0 0;
   font-size: 0.9rem;
-  color: #475569;
+  color: var(--color-gray-250);
 }
 
 .loadingState {
@@ -45,7 +45,7 @@
   align-items: center;
   padding: 2rem;
   font-size: 1.1rem;
-  color: #666;
+  color: var(--color-gray-500);
 }
 
 .errorState {
@@ -54,9 +54,9 @@
   align-items: center;
   padding: 2rem;
   font-size: 1.1rem;
-  color: #d32f2f;
-  background: #ffebee;
-  border: 1px solid #ffcdd2;
+  color: var(--color-danger-alt-5);
+  background: var(--color-danger-bg-3);
+  border: 1px solid var(--color-danger-bg-4);
   border-radius: 8px;
   margin: 1rem;
 }

--- a/src/FRONT/views/components/Footer.tsx
+++ b/src/FRONT/views/components/Footer.tsx
@@ -7,7 +7,7 @@ function Footer() {
   //   right: 0,
   //   bottom: 0,
   //   height: "4rem",
-  //   backgroundColor: "#1f2937",
+  //   backgroundColor: "var(--color-gray-800)",
   //   color: "white",
   //   paddingTop: "1rem",
   //   paddingBottom: "1rem",

--- a/src/FRONT/views/components/Redirect.module.css
+++ b/src/FRONT/views/components/Redirect.module.css
@@ -5,23 +5,23 @@
     align-items: center;
     justify-content: center;
     z-index: 9999;
-    background: rgba(0, 0, 0, 0.35);
+    background: rgba(var(--shadow-color), 0.35);
 }
 
 .redirect-box {
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: 12px;
+    gap: var(--space-3);
     padding: 18px;
-    background: #fff;
+    background: var(--color-white);
     border-radius: 10px;
-    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.18);
+    box-shadow: 0 8px 32px rgba(var(--shadow-color), 0.18);
     min-width: 180px;
 }
 
 .redirect-message {
     font-size: 15px;
-    color: #333;
+    color: var(--color-gray-600);
     font-weight: 600;
 }

--- a/src/FRONT/views/components/Redirect.tsx
+++ b/src/FRONT/views/components/Redirect.tsx
@@ -68,13 +68,13 @@ export const AutoRedirect = () => {
                 cx="0"
                 cy="0"
                 r="18"
-                stroke="#e6e6e6"
+                stroke="var(--color-surface-light-25)"
                 strokeWidth="6"
                 fill="none"
               />
               <path
                 d="M18 0 A18 18 0 0 1 0 18"
-                stroke="#333"
+                stroke="var(--color-gray-600)"
                 strokeWidth="6"
                 strokeLinecap="round"
                 fill="none"

--- a/src/FRONT/views/components/footer.module.css
+++ b/src/FRONT/views/components/footer.module.css
@@ -1,6 +1,6 @@
 .footer {
-  background-color: #1f2937;
-  color: white;
+  background-color: var(--color-gray-800);
+  color: var(--color-white);
   text-align: center;
   height: 3rem;
   display: flex;
@@ -20,6 +20,6 @@
   .footer {
     height: 4rem;
     font-size: 1.1rem;
-    padding: 0 30px;
+    padding: 0 var(--space-7);
   }
 }

--- a/src/FRONT/views/components/header.module.css
+++ b/src/FRONT/views/components/header.module.css
@@ -13,8 +13,8 @@
   left: 0;
   right: 0;
   height: 3.5rem; 
-  background-color: #1f2937; /* bg-gray-800 */
-  color: white;
+  background-color: var(--color-gray-800); /* bg-gray-800 */
+  color: var(--color-white);
   padding: 0.45rem 2rem 0.45rem 1.27rem;
   display: flex;
   align-items: center;
@@ -34,7 +34,7 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  color: white;
+  color: var(--color-white);
 }
 
 .title {
@@ -44,8 +44,8 @@
 }
 
 .button {
-  background-color: white;
-  color: #1f2937; /* text-gray-800 */
+  background-color: var(--color-white);
+  color: var(--color-gray-800); /* text-gray-800 */
   padding-left: 0.5rem; /* px-4 */
   padding-right: 0.5rem; /* px-4 */
   padding-top: 0.4rem; /* py-2 */
@@ -64,7 +64,7 @@
 }
 
 .button:hover {
-  background-color: #f3f4f6;
+  background-color: var(--color-gray-50);
 }
 
 .button:active {
@@ -72,7 +72,7 @@
 }
 
 .button:focus-visible {
-  outline: 2px solid #93c5fd;
+  outline: 2px solid var(--color-primary-light);
   outline-offset: 2px;
 }
 
@@ -87,7 +87,7 @@
   left: 0;
   right: 0;
   bottom: 0;
-  background-color: rgba(15, 23, 42, 0.35);
+  background-color: rgba(var(--color-slate-rgb), 0.35);
   backdrop-filter: blur(6px);
   z-index: 1100;
   animation: overlayFade 200ms ease;
@@ -102,10 +102,10 @@
   height: 100dvh;
   width: min(78vw, 300px);
   min-width: 240px;
-  background-color: white;
-  color: #111827;
-  border-left: 1px solid #e5e7eb;
-  box-shadow: 0 24px 60px rgba(15, 23, 42, 0.24);
+  background-color: var(--color-white);
+  color: var(--color-gray-900);
+  border-left: 1px solid var(--color-gray-200);
+  box-shadow: 0 24px 60px rgba(var(--color-slate-rgb), 0.24);
   z-index: 1200;
   transform: translateX(100%);
   transition: transform 320ms cubic-bezier(0.2, 0.8, 0.2, 1);
@@ -141,16 +141,16 @@
 .sidebarTitle {
   font-size: 0.95rem;
   font-weight: 600;
-  color: #1f2937;
+  color: var(--color-gray-800);
 }
 
 .closeButton {
   width: 2.2rem;
   height: 2.2rem;
   border-radius: 0.6rem;
-  border: 1px solid #e5e7eb;
-  background-color: #f3f4f6;
-  color: #1f2937;
+  border: 1px solid var(--color-gray-200);
+  background-color: var(--color-gray-50);
+  color: var(--color-gray-800);
   cursor: pointer;
   display: flex;
   align-items: center;
@@ -162,7 +162,7 @@
 }
 
 .closeButton:hover {
-  background-color: #e5e7eb;
+  background-color: var(--color-gray-200);
 }
 
 .closeButton:active {
@@ -170,7 +170,7 @@
 }
 
 .closeButton:focus-visible {
-  outline: 2px solid #93c5fd;
+  outline: 2px solid var(--color-primary-light);
   outline-offset: 2px;
 }
 
@@ -187,8 +187,8 @@
 .userCard {
   padding: 0.75rem 0.9rem;
   border-radius: 0.9rem;
-  background-color: #f8fafc;
-  border: 1px solid #e5e7eb;
+  background-color: var(--color-gray-25);
+  border: 1px solid var(--color-gray-200);
   display: flex;
   flex-direction: column;
   gap: 0.35rem;
@@ -196,7 +196,7 @@
 }
 
 .userName {
-  color: #1f2937;
+  color: var(--color-gray-800);
   font-size: 0.95rem;
   font-weight: 600;
   white-space: nowrap;
@@ -205,7 +205,7 @@
 }
 
 .userMeta {
-  color: #6b7280;
+  color: var(--color-gray-300);
   font-size: 0.8rem;
   white-space: nowrap;
   overflow: hidden;
@@ -230,7 +230,7 @@
 }
 
 .menuItem:not(:last-child) {
-  border-bottom: 1px solid rgba(31, 41, 55, 0.1);
+  border-bottom: 1px solid rgba(var(--color-gray-800-rgb), 0.1);
   padding-bottom: 0.35rem;
 }
 
@@ -240,7 +240,7 @@
   gap: 0.75rem;
   padding: 0.75rem 0.85rem;
   border-radius: 0.75rem;
-  color: #111827;
+  color: var(--color-gray-900);
   text-decoration: none;
   background-color: transparent;
   min-width: 0;
@@ -252,7 +252,7 @@
 }
 
 .menuLink:hover {
-  background-color: #f3f4f6;
+  background-color: var(--color-gray-50);
 }
 
 .menuLink:active {
@@ -260,7 +260,7 @@
 }
 
 .menuLink:focus-visible {
-  outline: 2px solid #93c5fd;
+  outline: 2px solid var(--color-primary-light);
   outline-offset: 2px;
 }
 
@@ -283,7 +283,7 @@
   margin-top: auto;
   padding-top: 0.75rem;
   padding-bottom: calc(0.75rem + env(safe-area-inset-bottom));
-  border-top: 1px solid #e5e7eb;
+  border-top: 1px solid var(--color-gray-200);
 }
 
 .logoutButton {
@@ -294,8 +294,8 @@
   padding: 0.8rem 0.85rem;
   border-radius: 0.8rem;
   border: none;
-  background-color: #1f2937;
-  color: white;
+  background-color: var(--color-gray-800);
+  color: var(--color-white);
   cursor: pointer;
   overflow: hidden;
   transition:
@@ -317,7 +317,7 @@
 }
 
 .logoutButton:hover {
-  background-color: #111827;
+  background-color: var(--color-gray-900);
 }
 
 .logoutButton:active {
@@ -325,7 +325,7 @@
 }
 
 .logoutButton:focus-visible {
-  outline: 2px solid #93c5fd;
+  outline: 2px solid var(--color-primary-light);
   outline-offset: 2px;
 }
 

--- a/src/FRONT/views/components/heroSection.module.css
+++ b/src/FRONT/views/components/heroSection.module.css
@@ -4,15 +4,15 @@
     flex-direction: column;
     gap: 18px;
     align-items: stretch;
-    padding: 18px 12px;
+    padding: 18px var(--space-3);
     font-family: 'Poppins', sans-serif;
-    color: #e6eef6;
+    color: var(--color-surface-light-2);
 }
 
 .content {
     display: flex;
     flex-direction: column;
-    gap: 12px;
+    gap: var(--space-3);
 }
 
 .logo {
@@ -27,12 +27,12 @@
     font-size: 1.5rem;
     line-height: 1.05;
     margin: 6px 0 0 0;
-    color: #00152b;
+    color: var(--color-surface-dark-900);
 }
 
 .accent {
     display: inline-block;
-    background: linear-gradient(90deg, #00152b, #00024b);
+    background: linear-gradient(90deg, var(--color-surface-dark-900), var(--color-surface-dark-700));
     background-clip: text;
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
@@ -41,14 +41,14 @@
 }
 
 .description {
-    color: rgba(0, 21, 43, 0.85);
+    color: rgba(var(--color-surface-dark-900-rgb), 0.85);
     font-size: 1.2rem;
     line-height: 1.4; 
 }
 .intro {
     
   font-size: 0.9rem;
-  color: #666;
+  color: var(--color-gray-500);
   margin-bottom: 0;
 
 }
@@ -56,7 +56,7 @@
 .ctaRow {
     display: flex;
     gap: 10px;
-    margin-top: 8px;
+    margin-top: var(--space-2);
 }
 
 .primaryButton {
@@ -74,16 +74,16 @@
 	cursor: pointer;
 	transition: background-color 0.3s ease, transform 0.2s ease, box-shadow 0.3s ease;
 	text-decoration: none;
-	background-color: #2b6cb0;
-	color: #ffffff;
-	box-shadow: 0 6px 15px rgba(43, 108, 176, 0.4);
+	background-color: var(--color-primary);
+	color: var(--color-white);
+	box-shadow: 0 6px 15px rgba(var(--color-primary-rgb), 0.4);
 }
 
 
 .mediaWrap {
     position: relative;
     width: 100%;
-    border-radius: 12px;
+    border-radius: var(--radius-md);
     overflow: hidden;
 }
 
@@ -97,7 +97,7 @@
 .imageOverlay {
     position: absolute;
     inset: 0;
-    background: linear-gradient(180deg, rgba(11,18,32,0.0) 0%, rgba(11,18,32,0.45) 100%);
+    background: linear-gradient(180deg, rgba(var(--color-navy-dark-rgb),0.0) 0%, rgba(var(--color-navy-dark-rgb),0.45) 100%);
 }
 
 @media (min-width: 768px) {

--- a/src/FRONT/views/components/infoSection.module.css
+++ b/src/FRONT/views/components/infoSection.module.css
@@ -1,10 +1,10 @@
 .infoSection {
     max-width: 100%;
-    margin: 20px 0;
+    margin: var(--space-5) 0;
     padding: 15px;
-    background-color: #ffffff;
-    border-radius: 12px;
-    box-shadow: 0 10px 25px rgba(0, 0, 0, 0.08);
+    background-color: var(--color-white);
+    border-radius: var(--radius-md);
+    box-shadow: 0 10px 25px var(--shadow-sm);
     animation: fadeIn 0.5s ease-out;
     display: flex;
     flex-direction: column;
@@ -12,16 +12,16 @@
 }
 
 .infoSectionTitle {
-    color: #002041;
+    color: var(--color-surface-dark-800);
     font-size: 1.5rem;
     font-weight: 700;
     margin: 0 0 2px 0;
 }
 
 .infoSectionContent {
-    color: rgba(0, 0, 0, 0.85);
+    color: rgba(var(--shadow-color), 0.85);
     font-size: 0.9rem;
-    margin: 0 0 8px 0;
+    margin: 0 0 var(--space-2) 0;
 }
 
 .cardsGrid {
@@ -33,10 +33,10 @@
 
 .sucursalContainer,
 .barberoContainer {
-    background-color: #f0f4f8;
-    border: 1px solid #e2e8f0;
+    background-color: var(--color-surface-light-1);
+    border: 1px solid var(--color-gray-100);
     border-radius: 8px;
-    padding: 12px;
+    padding: var(--space-3);
     margin-bottom: 10px;
     display: flex;
     flex-direction: column;
@@ -49,13 +49,13 @@
 .barberoContainer h3 {
     font-size: 1.1rem;
     font-weight: 700;
-    color: #2d3748;
+    color: var(--color-gray-700);
 }
 
 .sucursalInfo,
 .barberoInfo {
     font-size: 0.95rem;
-    color: #718096;
+    color: var(--color-gray-400);
     font-weight: 500;
 }
 
@@ -72,8 +72,8 @@
     text-align: center;
     padding: 10px;
     border-radius: 8px;
-    background: rgba(252, 252, 252, 0.01);
-    color: rgba(0, 0, 0, 0.85);
+    background: rgba(var(--color-white-rgb), 0.01);
+    color: rgba(var(--shadow-color), 0.85);
 }
 
 @media (min-width: 640px) {
@@ -81,9 +81,9 @@
         margin: 14px auto;
         width: 90%;
         max-width: 900px;
-        padding: 18px 20px;
+        padding: 18px var(--space-5);
         border-radius: 14px;
-        box-shadow: 0 8px 26px rgba(2, 6, 23, 0.5);
+        box-shadow: 0 8px 26px rgba(var(--color-navy-rgb), 0.5);
     }
 
     .infoSectionTitle {
@@ -92,21 +92,21 @@
 
     .cardsGrid {
         grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-        gap: 12px;
+        gap: var(--space-3);
     }
 
     .sucursalContainer,
     .barberoContainer {
-        padding: 12px 14px;
-        border-radius: 12px;
+        padding: var(--space-3) 14px;
+        border-radius: var(--radius-md);
         transition: transform 180ms ease, box-shadow 180ms ease;
     }
 
     .sucursalContainer:hover,
     .barberoContainer:hover {
         transform: translateY(-6px) scale(1.03);
-        box-shadow: 0 12px 32px rgba(43, 108, 176, 0.18), 0 2px 8px rgba(0, 0, 0, 0.08);
-        background-color: #e3eafc;
-        border-color: #2b6cb0;
+        box-shadow: 0 12px 32px rgba(var(--color-primary-rgb), 0.18), 0 2px 8px var(--shadow-sm);
+        background-color: var(--color-surface-light-3);
+        border-color: var(--color-primary);
     }
 }

--- a/src/FRONT/views/components/login/AuthContext.tsx
+++ b/src/FRONT/views/components/login/AuthContext.tsx
@@ -1,0 +1,98 @@
+// AuthContext.tsx (nuevo archivo)
+import React, { createContext, useContext, useState } from "react";
+
+interface User {
+  codUsuario: string;
+  dni: string;
+  cuil: string | null;
+  codSucursal: string | null;
+  nombre: string;
+  apellido: string;
+  telefono: string;
+  email: string;
+}
+
+interface AuthContextType {
+  user: User | null;
+  userType: "client" | "barber" | "admin" | null;
+  login: (userData: User) => void;
+  logout: () => void;
+  isAuthenticated: boolean;
+}
+
+const AuthContext = createContext<AuthContextType | undefined>(undefined);
+
+export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  
+
+  // Inicializar estado desde localStorage de forma sincrónica para evitar
+  // redirecciones prematuras al refrescar la página.
+  const [user, setUser] = useState<User | null>(() => {
+    try {
+      const saved = localStorage.getItem("user");
+      return saved ? (JSON.parse(saved) as User) : null;
+    } catch {
+      return null;
+    }
+  });
+
+  const [userType, setUserType] = useState<
+    "client" | "barber" | "admin" | null
+  >(() => {
+    try {
+      const t = localStorage.getItem("userType");
+      return t ? (t as "client" | "barber" | "admin") : null;
+    } catch {
+      return null;
+    }
+  });
+
+  const login = (userData: User) => {
+    const type =
+      userData.cuil === "1" ? "admin" : userData.cuil ? "barber" : "client";
+    setUser(userData);
+    setUserType(type);
+    try {
+      localStorage.setItem("user", JSON.stringify(userData));
+      localStorage.setItem("userType", type);
+    } catch (e) {
+      // Silencioso: localStorage puede fallar en modos strictos o de privacidad
+      console.warn("No se pudo guardar en localStorage", e);
+    }
+  };
+
+  const logout = () => {
+    setUser(null);
+    setUserType(null);
+    try {
+      localStorage.removeItem("user");
+      localStorage.removeItem("userType");
+    } catch (e) {
+      console.warn("No se pudo remover localStorage", e);
+    }
+  };
+
+  return (
+    <AuthContext.Provider
+      value={{
+        user,
+        userType,
+        login,
+        logout,
+        isAuthenticated: !!user,
+      }}
+    >
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+export const useAuth = () => {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error("useAuth must be used within AuthProvider");
+  }
+  return context;
+};

--- a/src/FRONT/views/components/login/createUser.tsx
+++ b/src/FRONT/views/components/login/createUser.tsx
@@ -1,0 +1,393 @@
+//! TERMINAR
+import React, { useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import styles from "./login.module.css";
+import toast from "react-hot-toast";
+import { UserBaseSchemaExport } from "../../../../BACK/Schemas/usersSchema";
+import {
+  PASSWORD_MAX_LENGTH,
+  PASSWORD_MIN_LENGTH,
+  PASSWORD_PATTERN,
+} from "../../lib/passwordConstants.ts";
+import { getPasswordMissing } from "../../lib/passwordRules";
+
+//! Mejoras FrontEnd
+/*
+1) formState: { isSubmitting }; es el mejor lock disponible de frontEnd
+2) <form onSubmit={handleSubmit(onSubmit)}>; prevención de errores
+3) aborController; resuelve problemas como request colgadas, multiples envios consecutivos, request tardías,
+hace que el backend procese menos 'basura' y mantiene un estado coherente
+4) fieldset disabled={isSubmitting}; bloquea inputs mientras se manda el form (no es seguro ya que es UX)
+5) if (error.name === "AbortError") return; manejo de errores
+6) Schema zod; aporta prevención de errores y a mantener la integridad de datos desde el front
+*/
+
+//! Utilizamos el Schema de la librería Zod para validar campos
+// Extend schema for form with password confirmation
+const CreateUserSchema = UserBaseSchemaExport.omit({
+  cuil: true,
+  codSucursal: true,
+})
+  .extend({
+    confirmarContraseña: z
+      .string()
+      .min(10, "Confirmar contraseña debe tener al menos 10 caracteres"),
+    preguntaSeguridad: z
+      .string()
+      .min(1, "Seleccione una pregunta de seguridad"),
+    respuestaSeguridad: z
+      .string()
+      .min(1, "Ingrese la respuesta a la pregunta de seguridad"),
+  })
+  .refine((data) => data.contraseña === data.confirmarContraseña, {
+    message: "Las contraseñas no coinciden",
+    path: ["confirmarContraseña"],
+  });
+
+type CreateUserFormData = z.infer<typeof CreateUserSchema>;
+//! isSubmitting es una estado de validación de formularios de la libreria react-hook-form para evitar multiples peticiones
+const CreateUser: React.FC = () => {
+  const navigate = useNavigate();
+  // AbortController ref para cancelar requests pendientes
+  const abortControllerRef = useRef<AbortController | null>(null);
+  const [showPassword, setShowPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+    reset,
+    watch,
+  } = useForm<CreateUserFormData>({
+    resolver: zodResolver(CreateUserSchema),
+    mode: "onBlur",
+  });
+
+  const passwordValue = watch("contraseña") || "";
+  const passwordMissing = getPasswordMissing(passwordValue);
+
+  const onSubmit = async (data: CreateUserFormData) => {
+    // Cancelar request anterior si existe
+    if (abortControllerRef.current) {
+      abortControllerRef.current.abort();
+    }
+
+    // Crear nuevo AbortController
+    abortControllerRef.current = new AbortController();
+
+    // 1. Inicias el Toast
+    const toastId = toast.loading("Creando Usuario...");
+
+    // 2. MAGIA: Separas lo que es del front (confirmación) de lo que va a la DB
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { confirmarContraseña: _, ...datosParaBackend } = data;
+
+    try {
+      const response = await fetch("/usuarios", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(datosParaBackend),
+        signal: abortControllerRef.current.signal,
+      });
+
+      // 3. Parseo directo a JSON (más limpio que text + parse)
+      const responseData = await response.json();
+
+      if (response.ok) {
+        // ÉXITO
+        toast.success(responseData.message || "Usuario creado exitosamente", {
+          id: toastId,
+          duration: 4000,
+        });
+
+        reset(); // Limpiar formulario
+
+        // Redirección con delay
+        setTimeout(() => {
+          navigate("/login");
+        }, 2000);
+      } else {
+        // ERROR DEL BACKEND (Ej: DNI duplicado)
+        toast.error(responseData.message || "Error al crear usuario", {
+          id: toastId,
+        });
+      }
+    } catch (error) {
+      // Ignorar errores de abort (son intencionales)
+      if (error instanceof Error && error.name === "AbortError") {
+        toast.dismiss(toastId);
+        console.log("Request cancelado");
+        return;
+      }
+      // ERROR DE RED
+      console.error("Error en handleSubmit:", error);
+      toast.error("No se pudo conectar con el servidor", { id: toastId });
+    }
+  };
+
+  return (
+    <section className={styles.about}>
+      <div className="container-fluid">
+        <div className="row">
+          <div className="col-12">
+            <form
+              className={`${styles.form} ${styles.formLong}`}
+              onSubmit={handleSubmit(onSubmit)}
+            >
+              {/*PROPIEDAD PARA DESHABILITAR ENVÍOS MULIPLES MEDIANTE HTML PURO  */}
+              <fieldset
+                disabled={isSubmitting}
+                style={{ border: "none", padding: 0, margin: 0 }}
+              >
+                <h1 className={styles.titleSignUp}>CREAR CUENTA</h1>
+
+                {/* DNI */}
+                <label>DNI:</label>
+                <input
+                  required
+                  type="text"
+                  placeholder="40300123"
+                  maxLength={8}
+                  {...register("dni")}
+                />
+                {errors.dni && (
+                  <p style={{ color: "red", fontSize: "0.875rem" }}>
+                    {errors.dni.message}
+                  </p>
+                )}
+
+                {/* NOMBRE */}
+                <label>Nombre:</label>
+                <input
+                  required
+                  type="text"
+                  placeholder="Juan"
+                  maxLength={50}
+                  {...register("nombre")}
+                />
+                {errors.nombre && (
+                  <p style={{ color: "red", fontSize: "0.875rem" }}>
+                    {errors.nombre.message}
+                  </p>
+                )}
+
+                {/* APELLIDO */}
+                <label>Apellido:</label>
+                <input
+                  required
+                  type="text"
+                  placeholder="Pérez"
+                  maxLength={50}
+                  {...register("apellido")}
+                />
+                {errors.apellido && (
+                  <p style={{ color: "red", fontSize: "0.875rem" }}>
+                    {errors.apellido.message}
+                  </p>
+                )}
+
+                {/* TELÉFONO */}
+                <label>Teléfono:</label>
+                <input
+                  required
+                  type="text"
+                  placeholder="+54 11 1234-5678"
+                  maxLength={20}
+                  {...register("telefono")}
+                />
+                {errors.telefono && (
+                  <p style={{ color: "red", fontSize: "0.875rem" }}>
+                    {errors.telefono.message}
+                  </p>
+                )}
+
+                {/* EMAIL */}
+                <label>Correo electrónico:</label>
+                <input
+                  required
+                  className={styles.formInput}
+                  type="email"
+                  placeholder="juan@ejemplo.com"
+                  maxLength={50}
+                  {...register("email")}
+                />
+                {errors.email && (
+                  <p style={{ color: "red", fontSize: "0.875rem" }}>
+                    {errors.email.message}
+                  </p>
+                )}
+
+                {/* CONTRASEÑA */}
+                <label>Contraseña:</label>
+                <div className={styles.inputWithIcon}>
+                  <input
+                    required
+                    type={showPassword ? "text" : "password"}
+                    placeholder="********"
+                    minLength={PASSWORD_MIN_LENGTH}
+                    maxLength={PASSWORD_MAX_LENGTH}
+                    pattern={PASSWORD_PATTERN}
+                    title={`Mínimo ${PASSWORD_MIN_LENGTH} caracteres; debe incluir mayúsculas, minúsculas, números y símbolos`}
+                    {...register("contraseña")}
+                  />
+                  <button
+                    type="button"
+                    className={styles.inputIconButton}
+                    onClick={() => setShowPassword((prev) => !prev)}
+                    aria-label={
+                      showPassword ? "Ocultar contraseña" : "Mostrar contraseña"
+                    }
+                    aria-pressed={showPassword}
+                  >
+                    <svg
+                      className={styles.inputIcon}
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      aria-hidden="true"
+                    >
+                      <path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7-11-7-11-7" />
+                      <circle cx="12" cy="12" r="3" />
+                    </svg>
+                  </button>
+                </div>
+                {passwordValue && passwordMissing.length > 0 && (
+                  <div className={styles.passwordHints}>
+                    <strong>Falta:</strong>
+                    <ul>
+                      {passwordMissing.map((item) => (
+                        <li key={item}>{item}</li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+                {errors.contraseña && (
+                  <p style={{ color: "red", fontSize: "0.875rem" }}>
+                    {errors.contraseña.message}
+                  </p>
+                )}
+
+                {/* CONFIRMAR CONTRASEÑA */}
+                <label>Confirmar contraseña:</label>
+                <div className={styles.inputWithIcon}>
+                  <input
+                    required
+                    type={showConfirmPassword ? "text" : "password"}
+                    placeholder="********"
+                    minLength={PASSWORD_MIN_LENGTH}
+                    maxLength={PASSWORD_MAX_LENGTH}
+                    {...register("confirmarContraseña")}
+                  />
+                  <button
+                    type="button"
+                    className={styles.inputIconButton}
+                    onClick={() => setShowConfirmPassword((prev) => !prev)}
+                    aria-label={
+                      showConfirmPassword
+                        ? "Ocultar contraseña"
+                        : "Mostrar contraseña"
+                    }
+                    aria-pressed={showConfirmPassword}
+                  >
+                    <svg
+                      className={styles.inputIcon}
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      aria-hidden="true"
+                    >
+                      <path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7-11-7-11-7" />
+                      <circle cx="12" cy="12" r="3" />
+                    </svg>
+                  </button>
+                </div>
+                {errors.confirmarContraseña && (
+                  <p style={{ color: "red", fontSize: "0.875rem" }}>
+                    {errors.confirmarContraseña.message}
+                  </p>
+                )}
+
+                {/* PREGUNTA DE SEGURIDAD */}
+                <label>Pregunta de seguridad:</label>
+                <select
+                  required
+                  {...register("preguntaSeguridad")}
+                  defaultValue=""
+                  className={styles.smallSelect}
+                >
+                  <option value="" disabled>
+                    Seleccione una pregunta
+                  </option>
+                  <option value="¿Cuál es el nombre de tu primera mascota?">
+                    ¿Cuál es el nombre de tu primera mascota?
+                  </option>
+                  <option value="¿Cuál es el nombre de la calle donde creciste?">
+                    ¿Cuál es el nombre de la calle donde creciste?
+                  </option>
+                  <option value="¿Cuál es el nombre de tu libro favorito?">
+                    ¿Cuál es el nombre de tu libro favorito?
+                  </option>
+                </select>
+                {errors.preguntaSeguridad && (
+                  <p style={{ color: "red", fontSize: "0.875rem" }}>
+                    {errors.preguntaSeguridad.message}
+                  </p>
+                )}
+
+                {/* RESPUESTA DE SEGURIDAD */}
+                <label>Respuesta de seguridad:</label>
+                <input
+                  required
+                  type="text"
+                  placeholder="Tu respuesta"
+                  maxLength={100}
+                  {...register("respuestaSeguridad")}
+                />
+                {errors.respuestaSeguridad && (
+                  <p style={{ color: "red", fontSize: "0.875rem" }}>
+                    {errors.respuestaSeguridad.message}
+                  </p>
+                )}
+                {/* Aplicacion del isSubmitting */}
+                <p className="has-text-centered">
+                  <br />
+                  <button
+                    type="submit"
+                    className="btn btn-primary"
+                    disabled={isSubmitting}
+                  >
+                    {isSubmitting ? "Creando..." : "Crear Cuenta"}
+                  </button>
+
+                  <button
+                    type="button"
+                    onClick={() => navigate("/login")}
+                    disabled={isSubmitting}
+                  >
+                    Volver al Login
+                  </button>
+                  <br />
+                  <br />
+                </p>
+              </fieldset>
+            </form>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default CreateUser;

--- a/src/FRONT/views/components/login/login.module.css
+++ b/src/FRONT/views/components/login/login.module.css
@@ -85,8 +85,8 @@
 }
 
 .inputIcon {
-  width: 20px;
-  height: 20px;
+  width: var(--space-5);
+  height: var(--space-5);
   display: block;
 }
 .form input[type="email"]:focus,
@@ -101,7 +101,7 @@
   margin: var(--space-4) auto;
   text-align: center;
   border: 2px solid var(--color-accent-green);
-  padding: var(--space-3) 32px;
+  padding: var(--space-3) var(--space-8);
   outline: none;
   color: var(--color-white);
   border-radius: var(--radius-lg);
@@ -121,7 +121,7 @@
   margin: var(--space-4) auto;
   text-align: center;
   border: 2px solid var(--color-black);
-  padding: var(--space-3) 32px;
+  padding: var(--space-3) var(--space-8);
   outline: none;
   transition: var(--transition-fast);
   cursor: pointer;
@@ -181,13 +181,13 @@
   font-size: var(--font-size-md);
 }
 
-/* DESKTOP */
+/* DESKTOP: ajustes para pantallas grandes */
 @media (min-width: 769px) {
   .form {
     padding: 0;
   }
   .formLong {
-    padding: 32px 10px 56px;
+    padding: var(--space-7) 10px 56px;
   }
   .form h1 {
     font-size: var(--font-size-3xl);

--- a/src/FRONT/views/components/login/login.tsx
+++ b/src/FRONT/views/components/login/login.tsx
@@ -1,0 +1,145 @@
+import React, { useState } from "react";
+import styles from "./login.module.css";
+import { PASSWORD_MAX_LENGTH } from "../../lib/passwordConstants.ts";
+import { Link } from "react-router-dom";
+import { useAuth } from "./AuthContext.tsx";
+import { useUserRedirect } from "../Redirect.tsx";
+import toast from "react-hot-toast";
+
+function Login() {
+  const [email, setEmail] = useState("");
+  const [contraseña, setContraseña] = useState("");
+  const [showPassword, setShowPassword] = useState(false);
+  const { login } = useAuth();
+  const { redirectUser } = useUserRedirect();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      const response = await fetch("/login", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email, contraseña }),
+      });
+      const text = await response.text();
+      let data;
+      if (text) {
+        try {
+          data = JSON.parse(text);
+        } catch {
+          toast.error("Respuesta inválida del servidor");
+          return;
+        }
+      } else {
+        toast.error("El servidor no devolvió respuesta.");
+        return;
+      }
+      if (response.ok) {
+        console.log("✅ Login successful, server response:", data);
+
+        // usar el contexto para manejar el login
+        if (data.user) {
+          console.log("User data received:", data.user);
+          console.log("User cuil:", data.user.cuil);
+
+          login(data.user);
+
+          // gancho de redirección
+          redirectUser(data.user, data.message || "Login exitoso");
+        } else {
+          console.log("No user data in response");
+          toast.error("Datos de usuario no encontrados");
+        }
+      } else {
+        console.log("Login failed, server response:", data);
+        toast.error(data?.message || "Error de login");
+      }
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    } catch (error) {
+      toast.error("Error de conexión");
+    }
+  };
+
+  return (
+    <section id="about" className={styles.about}>
+      <div className="container-fluid">
+        <div className="row ">
+          <div className="col-12">
+            <form
+              className={styles.form}
+              autoComplete="on"
+              onSubmit={handleSubmit}
+            >
+              <h1>INICIO DE SESIÓN</h1>
+              <br />
+              <label>Correo electrónico:</label>
+              <input
+                className="form-control"
+                type="email"
+                name="email"
+                placeholder="hola@ejemplo.com"
+                maxLength={70}
+                required
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+              />
+              <label>Contraseña:</label>
+              <div className={styles.inputWithIcon}>
+                <input
+                  className="form-control"
+                  type={showPassword ? "text" : "password"}
+                  name="claveUsuario"
+                  maxLength={PASSWORD_MAX_LENGTH}
+                  placeholder="********"
+                  required
+                  value={contraseña}
+                  onChange={(e) => setContraseña(e.target.value)}
+                />
+                <button
+                  type="button"
+                  className={styles.inputIconButton}
+                  onClick={() => setShowPassword((prev) => !prev)}
+                  aria-label={
+                    showPassword ? "Ocultar contraseña" : "Mostrar contraseña"
+                  }
+                  aria-pressed={showPassword}
+                >
+                  <svg
+                    className={styles.inputIcon}
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    aria-hidden="true"
+                  >
+                    <path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7-11-7-11-7" />
+                    <circle cx="12" cy="12" r="3" />
+                  </svg>
+                </button>
+              </div>
+              <p className="has-text-centered">
+                <br />
+                <button
+                  type="submit"
+                  className="btn btn-primary"
+                  value="Ingresar"
+                >
+                  Confirmar
+                </button>
+                <br />
+                <br />
+                <Link to="/changePassword">¿Has olvidado la contraseña?</Link>
+                <br />
+                <br />
+                <Link to="/signUp">Crear Cuenta</Link>
+              </p>
+            </form>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+export default Login;

--- a/src/FRONT/views/components/login/resetSecurity.tsx
+++ b/src/FRONT/views/components/login/resetSecurity.tsx
@@ -1,0 +1,280 @@
+import React, { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import toast from "react-hot-toast";
+import styles from "./login.module.css";
+import {
+  PASSWORD_MAX_LENGTH,
+  PASSWORD_MIN_LENGTH,
+  PASSWORD_PATTERN,
+} from "../../lib/passwordConstants.ts";
+import { getPasswordMissing } from "../../lib/passwordRules";
+
+const ResetSecurity: React.FC = () => {
+  const [step, setStep] = useState<"email" | "answer" | "password">("email");
+  const [email, setEmail] = useState("");
+  const [pregunta, setPregunta] = useState<string | null>(null);
+  const [respuesta, setRespuesta] = useState("");
+  const [nuevaContraseña, setNuevaContraseña] = useState("");
+  const [confirmarContraseña, setConfirmarContraseña] = useState("");
+  const [showNewPassword, setShowNewPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+  const navigate = useNavigate();
+
+  const askQuestion = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const cleanEmail = email.trim();
+    if (!cleanEmail) {
+      toast.error("Ingresá un correo válido");
+      return;
+    }
+    try {
+      const res = await fetch(
+        `/usuarios/security-question/${encodeURIComponent(cleanEmail)}`,
+      );
+      const data = await res.json();
+      if (res.ok) {
+        if (data.pregunta) {
+          setPregunta(data.pregunta);
+          setStep("answer");
+        } else {
+          toast.error("No se encontró pregunta para ese correo");
+        }
+      } else {
+        toast.error(data.message || "Error al obtener la pregunta");
+      }
+    } catch (err) {
+      console.error(err);
+      toast.error("Error de conexión");
+    }
+  };
+
+  const submitAnswer = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const cleanEmail = email.trim();
+    const cleanRespuesta = respuesta.trim();
+    if (!cleanEmail || !cleanRespuesta) {
+      toast.error("Email y respuesta son requeridos");
+      return;
+    }
+    try {
+      const res = await fetch(`/usuarios/verify-security-answer`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          email: cleanEmail,
+          respuestaSeguridad: cleanRespuesta,
+        }),
+      });
+      const data = await res.json();
+      if (res.ok) {
+        toast.success(data.message || "Respuesta verificada");
+        setStep("password");
+      } else {
+        toast.error(data?.message || "Error al verificar la respuesta");
+      }
+    } catch (err) {
+      console.error(err);
+      toast.error("Error de conexión");
+    }
+  };
+
+  const submitNewPassword = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const cleanEmail = email.trim();
+    const cleanRespuesta = respuesta.trim();
+    if (!cleanEmail || !cleanRespuesta) {
+      toast.error("Email y respuesta son requeridos");
+      return;
+    }
+    const missing = getPasswordMissing(nuevaContraseña);
+    if (missing.length > 0) {
+      toast.error(`Falta: ${missing.join(", ")}`);
+      return;
+    }
+    if (nuevaContraseña !== confirmarContraseña) {
+      toast.error("Las contraseñas no coinciden");
+      return;
+    }
+    try {
+      const res = await fetch(`/usuarios/reset-password`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          email: cleanEmail,
+          respuestaSeguridad: cleanRespuesta,
+          nuevaContraseña,
+        }),
+      });
+      const data = await res.json();
+      if (res.ok) {
+        toast.success(data.message || "Contraseña actualizada");
+        setTimeout(() => navigate("/login"), 1500);
+      } else {
+        toast.error(data?.message || "Error al actualizar");
+      }
+    } catch (err) {
+      console.error(err);
+      toast.error("Error de conexión");
+    }
+  };
+
+  return (
+    <section className={styles.about}>
+      <div className="container-fluid">
+        <div className="row">
+          <div className="col-12">
+            {step === "email" && (
+              <form className={styles.form} onSubmit={askQuestion}>
+                <h1>Recuperar contraseña</h1>
+                <label>Correo electrónico:</label>
+                <input
+                  type="email"
+                  placeholder="tu@correo.com"
+                  required
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                />
+                <p>
+                  <button type="submit" className="btn btn-primary">
+                    Siguiente
+                  </button>
+                  <button type="button" onClick={() => navigate("/login")}>
+                    Volver
+                  </button>
+                </p>
+              </form>
+            )}
+
+            {step === "answer" && (
+              <form className={styles.form} onSubmit={submitAnswer}>
+                <h1>Responder pregunta</h1>
+                <p>
+                  <strong>{pregunta}</strong>
+                </p>
+                <label>Respuesta:</label>
+                <input
+                  type="text"
+                  required
+                  value={respuesta}
+                  onChange={(e) => setRespuesta(e.target.value)}
+                />
+                <p>
+                  <button type="submit" className="btn btn-primary">
+                    Verificar respuesta
+                  </button>
+                  <button type="button" onClick={() => setStep("email")}>
+                    Volver
+                  </button>
+                </p>
+              </form>
+            )}
+
+            {step === "password" && (
+              <form className={styles.form} onSubmit={submitNewPassword}>
+                <h1>Nueva contraseña</h1>
+
+                <label>Nueva contraseña:</label>
+                <div className={styles.inputWithIcon}>
+                  <input
+                    type={showNewPassword ? "text" : "password"}
+                    required
+                    minLength={PASSWORD_MIN_LENGTH}
+                    maxLength={PASSWORD_MAX_LENGTH}
+                    pattern={PASSWORD_PATTERN}
+                    title={`Mínimo ${PASSWORD_MIN_LENGTH} caracteres; debe incluir mayúsculas, minúsculas, números y símbolos`}
+                    value={nuevaContraseña}
+                    onChange={(e) => setNuevaContraseña(e.target.value)}
+                  />
+                  <button
+                    type="button"
+                    className={styles.inputIconButton}
+                    onClick={() => setShowNewPassword((prev) => !prev)}
+                    aria-label={
+                      showNewPassword
+                        ? "Ocultar contraseña"
+                        : "Mostrar contraseña"
+                    }
+                    aria-pressed={showNewPassword}
+                  >
+                    <svg
+                      className={styles.inputIcon}
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      aria-hidden="true"
+                    >
+                      <path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7-11-7-11-7" />
+                      <circle cx="12" cy="12" r="3" />
+                    </svg>
+                  </button>
+                </div>
+                {nuevaContraseña &&
+                  getPasswordMissing(nuevaContraseña).length > 0 && (
+                    <div className={styles.passwordHints}>
+                      <strong>Falta:</strong>
+                      <ul>
+                        {getPasswordMissing(nuevaContraseña).map((item) => (
+                          <li key={item}>{item}</li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
+
+                <label>Confirmar nueva contraseña:</label>
+                <div className={styles.inputWithIcon}>
+                  <input
+                    type={showConfirmPassword ? "text" : "password"}
+                    required
+                    minLength={PASSWORD_MIN_LENGTH}
+                    maxLength={PASSWORD_MAX_LENGTH}
+                    value={confirmarContraseña}
+                    onChange={(e) => setConfirmarContraseña(e.target.value)}
+                  />
+                  <button
+                    type="button"
+                    className={styles.inputIconButton}
+                    onClick={() => setShowConfirmPassword((prev) => !prev)}
+                    aria-label={
+                      showConfirmPassword
+                        ? "Ocultar contraseña"
+                        : "Mostrar contraseña"
+                    }
+                    aria-pressed={showConfirmPassword}
+                  >
+                    <svg
+                      className={styles.inputIcon}
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      aria-hidden="true"
+                    >
+                      <path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7-11-7-11-7" />
+                      <circle cx="12" cy="12" r="3" />
+                    </svg>
+                  </button>
+                </div>
+
+                <p>
+                  <button type="submit" className="btn btn-primary">
+                    Cambiar contraseña
+                  </button>
+                  <button type="button" onClick={() => setStep("answer")}>
+                    Volver
+                  </button>
+                </p>
+              </form>
+            )}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default ResetSecurity;

--- a/src/FRONT/views/components/shared/TimeSlotPicker.module.css
+++ b/src/FRONT/views/components/shared/TimeSlotPicker.module.css
@@ -1,97 +1,97 @@
 .timeSlotContainer {
-  padding: 20px;
-  background: white;
+  padding: var(--space-5);
+  background: var(--color-white);
   border-radius: 8px;
 }
 
 .title {
   font-size: 1.5rem;
-  margin-bottom: 20px;
-  color: #333;
+  margin-bottom: var(--space-5);
+  color: var(--color-gray-600);
 }
 
 .loadingState,
 .errorState {
-  padding: 20px;
+  padding: var(--space-5);
   text-align: center;
   font-size: 1rem;
 }
 
 .errorState {
-  color: #dc3545;
+  color: var(--color-danger-alt-4);
 }
 
 .datePickerContainer {
-  margin-bottom: 20px;
+  margin-bottom: var(--space-5);
 }
 
 .datePickerContainer label {
   display: block;
-  margin-bottom: 8px;
+  margin-bottom: var(--space-2);
   font-weight: 500;
-  color: #333;
+  color: var(--color-gray-600);
 }
 
 .datePicker {
   width: 100%;
   padding: 10px;
-  border: 1px solid #ccc;
+  border: 1px solid var(--color-gray-60);
   border-radius: 4px;
   font-size: 1rem;
 }
 
 /* Container for all time slots */
 .horariosContainer {
-  margin: 20px 0;
+  margin: var(--space-5) 0;
 }
 
 /* Group of time slots by period (Morning, Afternoon, Evening) */
 .horarioGroup {
-  margin-bottom: 24px;
+  margin-bottom: var(--space-6);
 }
 
 .periodTitle {
   font-size: 1.1rem;
   font-weight: 600;
-  color: #2b6cb0;
-  margin-bottom: 12px;
-  padding-bottom: 8px;
-  border-bottom: 2px solid #e2e8f0;
+  color: var(--color-primary);
+  margin-bottom: var(--space-3);
+  padding-bottom: var(--space-2);
+  border-bottom: 2px solid var(--color-gray-100);
 }
 
 /* Three-column grid for time slots */
 .scheduleGrid {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .emptyState {
-  padding: 20px;
+  padding: var(--space-5);
   text-align: center;
-  color: #666;
+  color: var(--color-gray-500);
   font-style: italic;
 }
 
 .scheduleItem {
   padding: 10px 6px;
-  background: #f8f9fa;
+  background: var(--color-surface-light-19);
   border: 2px solid transparent;
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   transition: all 0.2s ease;
   cursor: pointer;
   text-align: center;
 }
 
 .scheduleItem:hover {
-  background: #e9ecef;
-  border-color: #007bff;
+  background: var(--color-surface-light-24);
+  border-color: var(--color-blue-bright);
 }
 
 .scheduleItem.selected {
-  background: #007bff;
-  color: white;
-  border-color: #0056b3;
+  background: var(--color-blue-bright);
+  color: var(--color-white);
+  border-color: var(--color-blue-bright-2);
 }
 
 .scheduleHour {
@@ -102,12 +102,12 @@
 
 .confirmButton {
   width: 100%;
-  padding: 12px 24px;
-  margin-top: 20px;
-  background: #28a745;
-  color: white;
+  padding: var(--space-3) var(--space-6);
+  margin-top: var(--space-5);
+  background: var(--color-success-alt-2);
+  color: var(--color-white);
   border: none;
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   font-size: 1rem;
   font-weight: 500;
   cursor: pointer;
@@ -115,11 +115,11 @@
 }
 
 .confirmButton:hover:not(:disabled) {
-  background: #218838;
+  background: var(--color-success-alt-3);
 }
 
 .confirmButton:disabled {
-  background: #6c757d;
+  background: var(--color-accent-gray-warm);
   cursor: not-allowed;
   opacity: 0.6;
 }
@@ -128,11 +128,11 @@
 @media (min-width: 769px) {
   .scheduleGrid {
     grid-template-columns: repeat(4, 1fr);
-    gap: 12px;
+    gap: var(--space-3);
   }
 
   .scheduleItem {
-    padding: 12px 8px;
+    padding: var(--space-3) var(--space-2);
   }
 
   .scheduleHour {

--- a/src/FRONT/views/index.css
+++ b/src/FRONT/views/index.css
@@ -1,5 +1,6 @@
 @import "tailwindcss";
-@import "https://fonts.googleapis.com/css2?family=Poppins:wght@200;300;400;500;600;700;800;900&display=swap"; 
+@import "https://fonts.googleapis.com/css2?family=Poppins:wght@200;300;400;500;600;700;800;900&display=swap";
+@import "./tokens.css";
 
 
 html, body, #root {

--- a/src/FRONT/views/pages/Admin/HomePageAdmin.module.css
+++ b/src/FRONT/views/pages/Admin/HomePageAdmin.module.css
@@ -3,8 +3,8 @@
 /* General Body and Root Styling */
 body {
   font-family: "poppins", sans-serif;
-  background-color: #f8f8f8;
-  color: #333;
+  background-color: var(--color-surface-light-18);
+  color: var(--color-gray-600);
   margin: 0;
   padding: 10px;
   line-height: 1.6;
@@ -17,20 +17,20 @@ body {
 h2 {
   /* mobile-first: textos más pequeños en móvil */
   font-size: 1.6rem;
-  color: #1a202c;
+  color: var(--color-gray-950);
   text-align: center;
-  margin-bottom: 20px;
+  margin-bottom: var(--space-5);
   font-weight: 700;
   letter-spacing: -0.025em;
 }
 
 .indexTurnos {
   max-width: 100%;
-  margin: 20px 0;
+  margin: var(--space-5) 0;
   padding: 15px;
-  background-color: #ffffff;
-  border-radius: 12px;
-  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.08);
+  background-color: var(--color-white);
+  border-radius: var(--radius-md);
+  box-shadow: 0 10px 25px var(--shadow-sm);
   animation: fadeIn 0.5s ease-out;
 }
 
@@ -41,41 +41,41 @@ h2 {
 }
 
 .indexTurnos li {
-  background-color: #f0f4f8;
-  border: 1px solid #e2e8f0;
+  background-color: var(--color-surface-light-1);
+  border: 1px solid var(--color-gray-100);
   border-radius: 8px;
-  padding: 12px;
+  padding: var(--space-3);
   margin-bottom: 10px;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--space-2);
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
 .indexTurnos li:hover {
   transform: translateY(-3px);
-  box-shadow: 0 6px 15px rgba(0, 0, 0, 0.05);
+  box-shadow: 0 6px 15px rgba(var(--shadow-color), 0.05);
 }
 
 .indexTurnos li strong {
   font-size: 1.1rem;
-  color: #2d3748;
+  color: var(--color-gray-700);
 }
 
 .indexTurnos li p {
   margin: 0;
-  color: #4a5568;
+  color: var(--color-gray-450);
 }
 
 /* Form Styles (for Create and Modificar) */
 
 .formContainer {
   max-width: 100%;
-  margin: 20px 0;
+  margin: var(--space-5) 0;
   padding: 15px;
-  background-color: #ffffff;
-  border-radius: 12px;
-  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.08);
+  background-color: var(--color-white);
+  border-radius: var(--radius-md);
+  box-shadow: 0 10px 25px var(--shadow-sm);
   animation: fadeIn 0.5s ease-out;
 }
 
@@ -87,29 +87,29 @@ h2 {
   display: block;
   margin-bottom: 6px;
   font-weight: 600;
-  color: #4a5568;
+  color: var(--color-gray-450);
   font-size: 0.95rem;
 }
 
 .formInput,
 .formSelect {
   width: 100%;
-  padding: 10px 12px;
-  border: 2px solid #a0aec0;
+  padding: 10px var(--space-3);
+  border: 2px solid var(--color-gray-125);
   border-radius: 8px;
   font-size: 0.95rem;
-  color: #2d3748;
+  color: var(--color-gray-700);
   transition: border-color 0.3s ease, box-shadow 0.3s ease;
   box-sizing: border-box;
-  box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.1);
+  box-shadow: inset 0 1px 3px var(--shadow-md);
 }
 
 .formInput:focus,
 .formSelect:focus {
   outline: none;
-  border-color: #4299e1;
-  box-shadow: 0 0 0 4px rgba(66, 153, 225, 0.6);
-  background-color: #e6f4ff;
+  border-color: var(--color-primary-hover);
+  box-shadow: 0 0 0 4px rgba(var(--color-primary-hover-rgb), 0.6);
+  background-color: var(--color-surface-light-4);
 }
 
 /* Buttons */
@@ -133,39 +133,39 @@ h2 {
 }
 
 .buttonPrimary {
-  background-color: #2b6cb0;
-  color: #ffffff;
-  box-shadow: 0 6px 15px rgba(43, 108, 176, 0.4);
+  background-color: var(--color-primary);
+  color: var(--color-white);
+  box-shadow: 0 6px 15px rgba(var(--color-primary-rgb), 0.4);
 }
 
 .buttonPrimary:hover {
-  background-color: #2c5282;
+  background-color: var(--color-blue-dark);
   transform: translateY(-3px);
-  box-shadow: 0 8px 20px rgba(43, 108, 176, 0.5);
+  box-shadow: 0 8px 20px rgba(var(--color-primary-rgb), 0.5);
 }
 
 .buttonDanger {
-  background-color: #c53030;
-  color: #ffffff;
-  box-shadow: 0 6px 15px rgba(197, 48, 48, 0.4);
+  background-color: var(--color-danger);
+  color: var(--color-white);
+  box-shadow: 0 6px 15px rgba(var(--color-danger-rgb), 0.4);
 }
 
 .buttonDanger:hover {
-  background-color: #9b2c2c;
+  background-color: var(--color-danger-mid);
   transform: translateY(-3px);
-  box-shadow: 0 8px 20px rgba(197, 48, 48, 0.5);
+  box-shadow: 0 8px 20px rgba(var(--color-danger-rgb), 0.5);
 }
 
 .buttonSuccess {
-  background-color: #38a169;
-  color: #ffffff;
-  box-shadow: 0 6px 15px rgba(56, 161, 105, 0.4);
+  background-color: var(--color-success);
+  color: var(--color-white);
+  box-shadow: 0 6px 15px rgba(var(--color-success-rgb), 0.4);
 }
 
 .buttonSuccess:hover {
-  background-color: #2f855a;
+  background-color: var(--color-success-mid);
   transform: translateY(-3px);
-  box-shadow: 0 8px 20px rgba(56, 161, 105, 0.5);
+  box-shadow: 0 8px 20px rgba(var(--color-success-rgb), 0.5);
 }
 
 .indexTurnos li .button {
@@ -189,8 +189,8 @@ h2 {
   display: flex;
   justify-content: center;
   align-items: center;
-  margin: 20px;
-  padding: 0 20px;
+  margin: var(--space-5);
+  padding: 0 var(--space-5);
 }
 
 /* Modificar el botón específicamente dentro del contenedor */
@@ -199,7 +199,7 @@ h2 {
   width: 100%;
   max-width: 100%;
   min-width: 0;
-  padding: 12px 18px;
+  padding: var(--space-3) 18px;
   flex-shrink: 0;
 }
 
@@ -215,45 +215,45 @@ h2 {
 .turnoTitle {
   font-size: 1.1rem;
   font-weight: 700;
-  color: #2d3748;
-  margin-bottom: 4px;
+  color: var(--color-gray-700);
+  margin-bottom: var(--space-1);
 }
 
 .turnoCode {
   font-size: 0.85rem;
-  color: #718096;
+  color: var(--color-gray-400);
   font-weight: 500;
 }
 
 .turnoDetails {
-  color: #4a5568;
+  color: var(--color-gray-450);
   line-height: 1.5;
-  margin-top: 4px;
+  margin-top: var(--space-1);
 }
 
 .turnoFecha {
-  color: #2d3748;
+  color: var(--color-gray-700);
   font-weight: 600;
 }
 
 .turnoHora {
-  color: #2b6cb0;
+  color: var(--color-primary);
   font-weight: 600;
 }
 
 /* Loading and empty states */
 .loadingState {
   text-align: center;
-  padding: 30px;
-  color: #718096;
+  padding: var(--space-7);
+  color: var(--color-gray-400);
   font-size: 1rem;
 }
 
 .loadingState,
 .emptyState {
   text-align: center;
-  padding: 30px;
-  color: #718096;
+  padding: var(--space-7);
+  color: var(--color-gray-400);
   font-size: 1rem;
 }
 
@@ -266,11 +266,11 @@ h2 {
 
 .mainTurnos {
   max-width: 100%;
-  margin: 20px auto;
+  margin: var(--space-5) auto;
   padding: 15px;
-  background-color: #ffffff;
-  border-radius: 12px;
-  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.08);
+  background-color: var(--color-white);
+  border-radius: var(--radius-md);
+  box-shadow: 0 10px 25px var(--shadow-sm);
   animation: fadeIn 0.5s ease-out;
 }
 
@@ -278,21 +278,21 @@ h2 {
   display: grid;
   grid-template-columns: 1fr;
   gap: 10px;
-  margin-top: 20px;
+  margin-top: var(--space-5);
 }
 
 .mainTurnosCard {
-  background-color: #f0f4f8;
-  border: 1px solid #e2e8f0;
+  background-color: var(--color-surface-light-1);
+  border: 1px solid var(--color-gray-100);
   border-radius: 8px;
-  padding: 12px;
+  padding: var(--space-3);
   text-align: center;
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
 .mainTurnosCard:hover {
   transform: translateY(-3px);
-  box-shadow: 0 6px 15px rgba(0, 0, 0, 0.05);
+  box-shadow: 0 6px 15px rgba(var(--shadow-color), 0.05);
 }
 
 .dashboardHeader {
@@ -303,14 +303,14 @@ h2 {
 .dashboardHeader h1 {
   /* mobile-first: tamaño más contenido en móvil */
   font-size: 1.8rem;
-  color: #333;
+  color: var(--color-gray-600);
   margin-bottom: 1rem;
   font-weight: 700;
 }
 
 .dashboardHeader p {
   font-size: 1.2rem;
-  color: #666;
+  color: var(--color-gray-500);
   margin-bottom: 0;
 }
 
@@ -323,13 +323,13 @@ h2 {
 }
 
 .dashboardCard {
-  background: #fff;
+  background: var(--color-white);
   border-radius: 15px;
   padding: 2rem;
   text-align: center;
   text-decoration: none;
-  color: #333;
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
+  color: var(--color-gray-600);
+  box-shadow: 0 4px 20px var(--shadow-md);
   transition: all 0.3s ease;
   border: 2px solid transparent;
   min-height: 200px;
@@ -341,9 +341,9 @@ h2 {
 
 .dashboardCard:hover {
   transform: translateY(-5px);
-  box-shadow: 0 8px 30px rgba(0, 0, 0, 0.15);
+  box-shadow: 0 8px 30px var(--shadow-lg);
   text-decoration: none;
-  color: #333;
+  color: var(--color-gray-600);
 }
 
 .cardIcon {
@@ -363,59 +363,59 @@ h2 {
 
 .dashboardCard p {
   font-size: 1rem;
-  color: #666;
+  color: var(--color-gray-500);
   margin-bottom: 0;
 }
 
 .categoriesCard .cardIcon {
-  color: #ff2600;
+  color: var(--color-danger-pure);
 }
 
 .barbersCard .cardIcon {
-  color: #f3aa21;
+  color: var(--color-warning-alt-3);
   width: 60px;
   height: 60px;
 }
 
 
 .haircutCard .cardIcon {
-  color: #fffb00;
+  color: var(--color-danger-pure-2);
 }
 
 .branchesCard .cardIcon {
-  color: #30aa00;
+  color: var(--color-accent-lime);
 }
 
 .clientsCard .cardIcon {
-  color: #1e2ce9;
+  color: var(--color-blue-bright-4);
 }
 
 .rentabilityCard .cardIcon {
-  color: #8b00e9;
+  color: var(--color-accent-purple);
 }
 
 /* DESKTOP: ajustes para pantallas grandes (overrides mobile-first) */
 @media (min-width: 769px) {
   body {
-    padding: 20px;
+    padding: var(--space-5);
   }
 
   .pageTitle,
   h2 {
     font-size: 2.5rem;
-    margin-bottom: 30px;
+    margin-bottom: var(--space-7);
   }
 
   .indexTurnos,
   .formContainer,
   .mainTurnos {
     max-width: 800px;
-    margin: 40px auto;
-    padding: 30px;
+    margin: var(--space-8) auto;
+    padding: var(--space-7);
   }
 
   .indexTurnos li {
-    padding: 20px;
+    padding: var(--space-5);
     gap: 10px;
     margin-bottom: 15px;
   }
@@ -439,8 +439,8 @@ h2 {
 
   .mainTurnosGrid {
     grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-    gap: 20px;
-    margin-top: 30px;
+    gap: var(--space-5);
+    margin-top: var(--space-7);
   }
 
   /* Desktop: hacer las tarjetas del dashboard más angostas */
@@ -456,24 +456,24 @@ h2 {
   }
 
   .mainTurnosCard {
-    padding: 20px;
+    padding: var(--space-5);
   }
 
   .loadingState,
   .emptyState {
-    padding: 40px;
+    padding: var(--space-8);
     font-size: 1.1rem;
   }
 
   .emptyState p {
     font-size: 1.1rem;
-    margin-bottom: 20px;
+    margin-bottom: var(--space-5);
   }
 
   .successMessage,
   .errorMessage {
-    padding: 12px 16px;
-    margin-bottom: 20px;
+    padding: var(--space-3) var(--space-4);
+    margin-bottom: var(--space-5);
   }
 
   /* Desktop overrides (mobile-first): make container buttons intrinsic width */
@@ -482,7 +482,7 @@ h2 {
     /* override base 100% */
     max-width: 280px;
     min-width: 200px;
-    padding: 12px 24px;
+    padding: var(--space-3) var(--space-6);
   }
 
   /* Desktop: primary button should fit its content and be centered */
@@ -490,32 +490,32 @@ h2 {
     width: fit-content !important;
     margin-left: auto;
     margin-right: auto;
-    padding: 12px 24px;
+    padding: var(--space-3) var(--space-6);
   }
 
   /* Colores específicos para cada tarjeta */
   .categoriesCard:hover {
-    border-color: #ff2600;
+    border-color: var(--color-danger-pure);
   }
 
   .barbersCard:hover {
-    border-color: #f3aa21;
+    border-color: var(--color-warning-alt-3);
   }
 
   .haircutCard:hover {
-    border-color: #fffb00;
+    border-color: var(--color-danger-pure-2);
   }
 
   .branchesCard:hover {
-    border-color: #30aa00;
+    border-color: var(--color-accent-lime);
   }
 
   .clientsCard:hover {
-    border-color: #1e2ce9;
+    border-color: var(--color-blue-bright-4);
   }
 
   .rentabilityCard:hover {
-    border-color: #8b00e9;
+    border-color: var(--color-accent-purple);
   }
 
 }
@@ -558,20 +558,20 @@ h2 {
 
 /* Success message styling */
 .successMessage {
-  background-color: #c6f6d5;
-  color: #22543d;
-  padding: 10px 12px;
+  background-color: var(--color-success-bg);
+  color: var(--color-success-dark);
+  padding: 10px var(--space-3);
   border-radius: 8px;
   margin-bottom: 15px;
-  border-left: 4px solid #38a169;
+  border-left: 4px solid var(--color-success);
 }
 
 /* Error message styling */
 .errorMessage {
-  background-color: #fed7d7;
-  color: #742a2a;
-  padding: 10px 12px;
+  background-color: var(--color-danger-bg);
+  color: var(--color-danger-dark);
+  padding: 10px var(--space-3);
   border-radius: 8px;
   margin-bottom: 15px;
-  border-left: 4px solid #e53e3e;
+  border-left: 4px solid var(--color-danger-bright);
 }

--- a/src/FRONT/views/pages/Admin/RentabilityByBranch.module.css
+++ b/src/FRONT/views/pages/Admin/RentabilityByBranch.module.css
@@ -1,8 +1,8 @@
 .controlsRow {
     display: flex;
-    gap: 12px;
+    gap: var(--space-3);
     align-items: center;
-    margin-left: 12px;
+    margin-left: var(--space-3);
     margin-bottom: 18px;
     flex-wrap: wrap;
 }
@@ -26,28 +26,28 @@
 
 .thLeft {
     text-align: left;
-    padding: 12px;
-    border-bottom: 1px solid #ddd;
+    padding: var(--space-3);
+    border-bottom: 1px solid var(--color-gray-75);
 }
 
 .thRight {
     text-align: right;
-    padding: 12px;
-    border-bottom: 1px solid #ddd;
+    padding: var(--space-3);
+    border-bottom: 1px solid var(--color-gray-75);
 }
 
 .tdCell {
-    padding: 12px;
-    border-bottom: 1px solid #f0f0f0;
+    padding: var(--space-3);
+    border-bottom: 1px solid var(--color-surface-light-20);
 }
 
 .tdRight {
-    padding: 12px;
-    border-bottom: 1px solid #f0f0f0;
+    padding: var(--space-3);
+    border-bottom: 1px solid var(--color-surface-light-20);
     text-align: right;
 }
 
 .emptyRow {
-    padding: 12px;
+    padding: var(--space-3);
     text-align: center;
 }

--- a/src/FRONT/views/pages/Barber/HomePageBarber.module.css
+++ b/src/FRONT/views/pages/Barber/HomePageBarber.module.css
@@ -1,7 +1,7 @@
 body {
   font-family: "Inter", sans-serif;
-  background-color: #f8f8f8;
-  color: #333;
+  background-color: var(--color-surface-light-18);
+  color: var(--color-gray-600);
   margin: 0;
   padding: 10px;
   line-height: 1.6;
@@ -45,12 +45,12 @@ body {
   margin: 0;
   font-size: 2.15rem;
   font-weight: 700;
-  color: #1f2937;
+  color: var(--color-gray-800);
 }
 
 .welcomeSubtitle {
   margin: 0.35rem 0 0;
-  color: #6b7280;
+  color: var(--color-gray-300);
   font-size: 0.98rem;
 }
 
@@ -68,16 +68,16 @@ body {
   margin: 0;
   font-size: 1.1rem;
   font-weight: 700;
-  color: #1f2937;
+  color: var(--color-gray-800);
 }
 
 .turnoCard {
   width: 100%;
   padding: 1rem;
   border-radius: 16px;
-  background: linear-gradient(180deg, #f8fafc 0%, #ffffff 100%);
-  border: 1px solid #e5e7eb;
-  box-shadow: 0 10px 22px rgba(15, 23, 42, 0.06);
+  background: linear-gradient(180deg, var(--color-gray-25) 0%, var(--color-white) 100%);
+  border: 1px solid var(--color-gray-200);
+  box-shadow: 0 10px 22px rgba(var(--color-slate-rgb), 0.06);
 }
 
 .turnoCardContent {
@@ -95,9 +95,9 @@ body {
   min-width: 72px;
   padding: 0.7rem 0.5rem;
   border-radius: 14px;
-  background: #2b6cb0;
-  color: #ffffff;
-  box-shadow: 0 10px 18px rgba(43, 108, 176, 0.22);
+  background: var(--color-primary);
+  color: var(--color-white);
+  box-shadow: 0 10px 18px rgba(var(--color-primary-rgb), 0.22);
 }
 
 .turnoDateMonth {
@@ -129,12 +129,12 @@ body {
 
 .turnoInfoIcon {
   flex-shrink: 0;
-  color: #2b6cb0;
+  color: var(--color-primary);
 }
 
 .turnoInfoText {
   font-size: 0.98rem;
-  color: #374151;
+  color: var(--color-gray-750);
   font-weight: 600;
   white-space: nowrap;
   overflow: hidden;
@@ -144,7 +144,7 @@ body {
 .cardEmpty {
   margin: 0;
   padding: 0.45rem 0;
-  color: #6b7280;
+  color: var(--color-gray-300);
   font-size: 0.98rem;
   text-align: center;
 }
@@ -180,19 +180,19 @@ body {
     transform 0.2s ease,
     box-shadow 0.3s ease;
   text-decoration: none;
-  background-color: #2b6cb0;
-  color: #ffffff;
-  box-shadow: 0 6px 15px rgba(43, 108, 176, 0.4);
+  background-color: var(--color-primary);
+  color: var(--color-white);
+  box-shadow: 0 6px 15px rgba(var(--color-primary-rgb), 0.4);
 }
 
 .optionButton:hover:not(:disabled) {
-  background-color: #2c5282;
+  background-color: var(--color-blue-dark);
   transform: translateY(-3px);
-  box-shadow: 0 8px 20px rgba(43, 108, 176, 0.5);
+  box-shadow: 0 8px 20px rgba(var(--color-primary-rgb), 0.5);
 }
 
 .optionButton:disabled {
-  background: #aaa;
+  background: var(--color-gray-45);
   cursor: not-allowed;
 }
 
@@ -210,9 +210,9 @@ body {
 /* DESKTOP: ajustes para pantallas grandes */
 @media (min-width: 769px) {
   .homeContainer {
-    margin: 40px auto;
+    margin: var(--space-8) auto;
     max-width: 800px;
-    padding: 24px 0;
+    padding: var(--space-6) 0;
   }
   .welcomeHeader {
     flex-direction: row;
@@ -229,12 +229,12 @@ body {
     padding: 1.2rem;
   }
   .optionsContainer {
-    gap: 20px;
+    gap: var(--space-5);
     width: 100%;
-    margin-top: 30px;
+    margin-top: var(--space-7);
     flex-direction: column;     /* En desktop se ponen uno al lado del otro */
     justify-content: center; /* ESTO centra el grupo de botones horizontalmente */
-    margin-top: 20px;
+    margin-top: var(--space-5);
   }
   .optionButton {
     width: 500px;

--- a/src/FRONT/views/pages/Client/HomePageClient.module.css
+++ b/src/FRONT/views/pages/Client/HomePageClient.module.css
@@ -1,8 +1,8 @@
 /* General Body and Root Styling */
 body {
   font-family: "Inter", sans-serif;
-  background-color: #f8f8f8;
-  color: #333;
+  background-color: var(--color-surface-light-18);
+  color: var(--color-gray-600);
   margin: 0;
   padding: 10px;
   line-height: 1.6;
@@ -13,20 +13,20 @@ body {
 .pageTitle,
 h2 {
   font-size: 2rem;
-  color: #1a202c;
+  color: var(--color-gray-950);
   text-align: center;
-  margin-bottom: 20px;
+  margin-bottom: var(--space-5);
   font-weight: 700;
   letter-spacing: -0.025em;
 }
 
 .indexTurnos {
   max-width: 100%;
-  margin: 20px 0;
+  margin: var(--space-5) 0;
   padding: 15px;
-  background-color: #ffffff;
-  border-radius: 12px;
-  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.08);
+  background-color: var(--color-white);
+  border-radius: var(--radius-md);
+  box-shadow: 0 10px 25px var(--shadow-sm);
   animation: fadeIn 0.5s ease-out;
 }
 
@@ -37,42 +37,42 @@ h2 {
 
 
 .indexTurnos li {
-  background-color: #f0f4f8;
-  border: 1px solid #e2e8f0;
+  background-color: var(--color-surface-light-1);
+  border: 1px solid var(--color-gray-100);
   border-radius: 8px;
-  padding: 12px;
+  padding: var(--space-3);
   margin-bottom: 10px;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--space-2);
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
 .indexTurnos li:hover {
   transform: translateY(-3px);
-  box-shadow: 0 6px 15px rgba(0, 0, 0, 0.05);
+  box-shadow: 0 6px 15px rgba(var(--shadow-color), 0.05);
 }
 
 
 .indexTurnos li strong {
   font-size: 1.1rem;
-  color: #2d3748;
+  color: var(--color-gray-700);
 }
 
 .indexTurnos li p {
   margin: 0;
-  color: #4a5568;
+  color: var(--color-gray-450);
 }
 
 /* Form Styles (for Create and Modificar) */
 
 .formContainer {
   max-width: 100%;
-  margin: 20px 0;
+  margin: var(--space-5) 0;
   padding: 15px;
-  background-color: #ffffff;
-  border-radius: 12px;
-  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.08);
+  background-color: var(--color-white);
+  border-radius: var(--radius-md);
+  box-shadow: 0 10px 25px var(--shadow-sm);
   animation: fadeIn 0.5s ease-out;
 }
 
@@ -86,7 +86,7 @@ h2 {
   display: block;
   margin-bottom: 6px;
   font-weight: 600;
-  color: #4a5568;
+  color: var(--color-gray-450);
   font-size: 0.95rem;
 }
 
@@ -94,23 +94,23 @@ h2 {
 .formInput,
 .formSelect {
   width: 100%;
-  padding: 10px 12px;
-  border: 2px solid #a0aec0;
+  padding: 10px var(--space-3);
+  border: 2px solid var(--color-gray-125);
   border-radius: 8px;
   font-size: 0.95rem;
-  color: #2d3748;
+  color: var(--color-gray-700);
   transition: border-color 0.3s ease, box-shadow 0.3s ease;
   box-sizing: border-box;
-  box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.1);
-  background-color: #ffffff;
+  box-shadow: inset 0 1px 3px var(--shadow-md);
+  background-color: var(--color-white);
 }
 
 .formInput:focus,
 .formSelect:focus {
   outline: none;
-  border-color: #4299e1;
-  box-shadow: 0 0 0 4px rgba(66, 153, 225, 0.6);
-  background-color: #e6f4ff;
+  border-color: var(--color-primary-hover);
+  box-shadow: 0 0 0 4px rgba(var(--color-primary-hover-rgb), 0.6);
+  background-color: var(--color-surface-light-4);
 }
 
 /* Buttons */
@@ -133,39 +133,39 @@ h2 {
 
 
 .buttonPrimary {
-  background-color: #2b6cb0;
-  color: #ffffff;
-  box-shadow: 0 6px 15px rgba(43, 108, 176, 0.4);
+  background-color: var(--color-primary);
+  color: var(--color-white);
+  box-shadow: 0 6px 15px rgba(var(--color-primary-rgb), 0.4);
 }
 
 .buttonPrimary:hover {
-  background-color: #2c5282;
+  background-color: var(--color-blue-dark);
   transform: translateY(-3px);
-  box-shadow: 0 8px 20px rgba(43, 108, 176, 0.5);
+  box-shadow: 0 8px 20px rgba(var(--color-primary-rgb), 0.5);
 }
 
 .buttonDanger {
-  background-color: #c53030;
-  color: #ffffff;
-  box-shadow: 0 6px 15px rgba(197, 48, 48, 0.4);
+  background-color: var(--color-danger);
+  color: var(--color-white);
+  box-shadow: 0 6px 15px rgba(var(--color-danger-rgb), 0.4);
 }
 
 .buttonDanger:hover {
-  background-color: #9b2c2c;
+  background-color: var(--color-danger-mid);
   transform: translateY(-3px);
-  box-shadow: 0 8px 20px rgba(197, 48, 48, 0.5);
+  box-shadow: 0 8px 20px rgba(var(--color-danger-rgb), 0.5);
 }
 
 .buttonSuccess {
-  background-color: #38a169;
-  color: #ffffff;
-  box-shadow: 0 6px 15px rgba(56, 161, 105, 0.4);
+  background-color: var(--color-success);
+  color: var(--color-white);
+  box-shadow: 0 6px 15px rgba(var(--color-success-rgb), 0.4);
 }
 
 .buttonSuccess:hover {
-  background-color: #2f855a;
+  background-color: var(--color-success-mid);
   transform: translateY(-3px);
-  box-shadow: 0 8px 20px rgba(56, 161, 105, 0.5);
+  box-shadow: 0 8px 20px rgba(var(--color-success-rgb), 0.5);
 }
 
 /* Specific adjustment for buttons within list items in IndexTurnos */
@@ -198,33 +198,33 @@ h2 {
 .turnoTitle {
   font-size: 1.1rem;
   font-weight: 700;
-  color: #2d3748;
-  margin-bottom: 4px;
+  color: var(--color-gray-700);
+  margin-bottom: var(--space-1);
 }
 
 
 .turnoCode {
   font-size: 0.85rem;
-  color: #718096;
+  color: var(--color-gray-400);
   font-weight: 500;
 }
 
 
 .turnoDetails {
-  color: #4a5568;
+  color: var(--color-gray-450);
   line-height: 1.5;
-  margin-top: 4px;
+  margin-top: var(--space-1);
 }
 
 
 .turnoFecha {
-  color: #2d3748;
+  color: var(--color-gray-700);
   font-weight: 600;
 }
 
 
 .turnoHora {
-  color: #2b6cb0;
+  color: var(--color-primary);
   font-weight: 600;
 }
 
@@ -233,8 +233,8 @@ h2 {
 .loadingState,
 .emptyState {
   text-align: center;
-  padding: 30px;
-  color: #718096;
+  padding: var(--space-7);
+  color: var(--color-gray-400);
   font-size: 1rem;
 }
 
@@ -247,11 +247,11 @@ h2 {
 
 .mainTurnos {
   max-width: 100%;
-  margin: 20px 0;
+  margin: var(--space-5) 0;
   padding: 15px;
-  background-color: #ffffff;
-  border-radius: 12px;
-  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.08);
+  background-color: var(--color-white);
+  border-radius: var(--radius-md);
+  box-shadow: 0 10px 25px var(--shadow-sm);
   animation: fadeIn 0.5s ease-out;
 }
 
@@ -259,21 +259,21 @@ h2 {
   display: grid;
   grid-template-columns: 1fr;
   gap: 10px;
-  margin-top: 20px;
+  margin-top: var(--space-5);
 }
 
 .mainTurnosCard {
-  background-color: #f0f4f8;
-  border: 1px solid #e2e8f0;
+  background-color: var(--color-surface-light-1);
+  border: 1px solid var(--color-gray-100);
   border-radius: 8px;
-  padding: 12px;
+  padding: var(--space-3);
   text-align: center;
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
 .mainTurnosCard:hover {
   transform: translateY(-3px);
-  box-shadow: 0 6px 15px rgba(0, 0, 0, 0.05);
+  box-shadow: 0 6px 15px rgba(var(--shadow-color), 0.05);
 }
 
 
@@ -282,17 +282,17 @@ h2 {
   .pageTitle,
   h2 {
     font-size: 2.5rem;
-    margin-bottom: 30px;
+    margin-bottom: var(--space-7);
   }
   .indexTurnos,
   .formContainer,
   .mainTurnos {
     max-width: 800px;
-    margin: 40px auto;
-    padding: 30px;
+    margin: var(--space-8) auto;
+    padding: var(--space-7);
   }
   .indexTurnos li {
-    padding: 20px;
+    padding: var(--space-5);
     gap: 10px;
     margin-bottom: 15px;
   }
@@ -312,25 +312,25 @@ h2 {
   }
   .mainTurnosGrid {
     grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-    gap: 20px;
-    margin-top: 30px;
+    gap: var(--space-5);
+    margin-top: var(--space-7);
   }
   .mainTurnosCard {
-    padding: 20px;
+    padding: var(--space-5);
   }
   .loadingState,
   .emptyState {
-    padding: 40px;
+    padding: var(--space-8);
     font-size: 1.1rem;
   }
   .emptyState p {
     font-size: 1.1rem;
-    margin-bottom: 20px;
+    margin-bottom: var(--space-5);
   }
   .successMessage,
   .errorMessage {
-    padding: 12px 16px;
-    margin-bottom: 20px;
+    padding: var(--space-3) var(--space-4);
+    margin-bottom: var(--space-5);
   }
 }
 
@@ -349,20 +349,20 @@ h2 {
 
 /* Success message styling */
 .successMessage {
-  background-color: #c6f6d5;
-  color: #22543d;
-  padding: 12px 16px;
+  background-color: var(--color-success-bg);
+  color: var(--color-success-dark);
+  padding: var(--space-3) var(--space-4);
   border-radius: 8px;
-  margin-bottom: 20px;
-  border-left: 4px solid #38a169;
+  margin-bottom: var(--space-5);
+  border-left: 4px solid var(--color-success);
 }
 
 /* Error message styling */
 .errorMessage {
-  background-color: #fed7d7;
-  color: #742a2a;
-  padding: 12px 16px;
+  background-color: var(--color-danger-bg);
+  color: var(--color-danger-dark);
+  padding: var(--space-3) var(--space-4);
   border-radius: 8px;
-  margin-bottom: 20px;
-  border-left: 4px solid #e53e3e;
+  margin-bottom: var(--space-5);
+  border-left: 4px solid var(--color-danger-bright);
 }

--- a/src/FRONT/views/tokens.css
+++ b/src/FRONT/views/tokens.css
@@ -1,0 +1,196 @@
+/* ============================================================
+   DESIGN TOKENS
+   Variables CSS centralizadas: colores, espaciados y tamaños.
+   Se importa una sola vez a nivel global (index.css) y se usa
+   var(--token) en los .module.css en lugar de valores hardcodeados.
+   ============================================================ */
+
+:root {
+  /* ---------- Colores de marca / acento ---------- */
+  --color-primary: #2b6cb0;
+  --color-primary-light: #93c5fd;
+  --color-primary-hover: #4299e1;
+  --color-accent-blue: #3498db;
+  --color-accent-green: #2ecc71;
+
+  /* ---------- Colores de estado ---------- */
+  --color-success: #38a169;
+  --color-danger: #c53030;
+  --color-warning: #dd6b20;
+
+  /* ---------- Escala de grises / neutros ---------- */
+  --color-gray-950: #1a202c;
+  --color-gray-900: #111827;
+  --color-gray-850: #2c3e50;
+  --color-gray-800: #1f2937;
+  --color-gray-750: #374151;
+  --color-gray-700: #2d3748;
+  --color-gray-650: #404855;
+  --color-gray-600: #333333;
+  --color-gray-500: #666666;
+  --color-gray-450: #4a5568;
+  --color-gray-400: #718096;
+  --color-gray-350: #64748b;
+  --color-gray-300: #6b7280;
+  --color-gray-250: #475569;
+  --color-gray-200: #e5e7eb;
+  --color-gray-150: #cbd5e0;
+  --color-gray-125: #a0aec0;
+  --color-gray-100: #e2e8f0;
+  --color-gray-75: #dddddd;
+  --color-gray-60: #cccccc;
+  --color-gray-50: #f3f4f6;
+  --color-gray-45: #aaaaaa;
+  --color-gray-40: #8a8a8a;
+  --color-gray-30: #555555;
+  --color-gray-25: #f8fafc;
+  --color-gray-20: #363636;
+
+  /* ---------- Fondos y superficies oscuras (header/footer) ---------- */
+  --color-surface-dark-900: #00152b;
+  --color-surface-dark-800: #002041;
+  --color-surface-dark-700: #00024b;
+
+  /* ---------- Colores adicionales (superficies claras) ---------- */
+  --color-surface-light-1: #f0f4f8;
+  --color-surface-light-2: #e6eef6;
+  --color-surface-light-3: #e3eafc;
+  --color-surface-light-4: #e6f4ff;
+  --color-surface-light-5: #eef2f6;
+  --color-surface-light-6: #e5eaf0;
+  --color-surface-light-7: #d7e1ee;
+  --color-surface-light-8: #e6f0ff;
+  --color-surface-light-9: #e6eef8;
+  --color-surface-light-10: #e6edf3;
+  --color-surface-light-11: #e3e9ef;
+  --color-surface-light-12: #d7e7ff;
+  --color-surface-light-13: #c8dcff;
+  --color-surface-light-14: #cbd5f5;
+  --color-surface-light-15: #fbfdff;
+  --color-surface-light-16: #f9fafb;
+  --color-surface-light-17: #f9f9f9;
+  --color-surface-light-18: #f8f8f8;
+  --color-surface-light-19: #f8f9fa;
+  --color-surface-light-20: #f0f0f0;
+  --color-surface-light-21: #f7fafc;
+  --color-surface-light-22: #edf2f7;
+  --color-surface-light-23: #ecf0f1;
+  --color-surface-light-24: #e9ecef;
+  --color-surface-light-25: #e6e6e6;
+  --color-surface-light-26: #d5dce3;
+
+  /* ---------- Verdes (éxito) ---------- */
+  --color-success-dark: #22543d;
+  --color-success-mid: #2f855a;
+  --color-success-mid-2: #276749;
+  --color-success-bright: #48bb78;
+  --color-success-bright-2: #38b2ac;
+  --color-success-alt: #27ae60;
+  --color-success-alt-2: #28a745;
+  --color-success-alt-3: #218838;
+  --color-success-alt-4: #059669;
+  --color-success-alt-5: #10b981;
+  --color-success-bg: #c6f6d5;
+
+  /* ---------- Rojos (error/peligro) ---------- */
+  --color-danger-bright: #e53e3e;
+  --color-danger-mid: #9b2c2c;
+  --color-danger-dark: #742a2a;
+  --color-danger-bg: #fed7d7;
+  --color-danger-bg-2: #fff5f5;
+  --color-danger-bg-3: #ffebee;
+  --color-danger-bg-4: #ffcdd2;
+  --color-danger-alt: #e74c3c;
+  --color-danger-alt-2: #ef4444;
+  --color-danger-alt-3: #f56565;
+  --color-danger-alt-4: #dc3545;
+  --color-danger-alt-5: #d32f2f;
+  --color-danger-pure: #ff2600;
+  --color-danger-pure-2: #fffb00;
+  --color-error-red: #b00020;
+  --color-link-red: #ff0000;
+
+  /* ---------- Azules (info / enlaces / foco) ---------- */
+  --color-blue-dark: #2c5282;
+  --color-blue-mid: #3182ce;
+  --color-blue-bright: #007bff;
+  --color-blue-bright-2: #0056b3;
+  --color-blue-bright-3: #3b82f6;
+  --color-blue-bright-4: #1e2ce9;
+  --color-blue-soft: #bee3f8;
+
+  /* ---------- Naranjas (advertencia) ---------- */
+  --color-warning-dark: #c05621;
+  --color-warning-alt: #e67e22;
+  --color-warning-alt-2: #ed8936;
+  --color-warning-alt-3: #f3aa21;
+
+  /* ---------- Colores fuera de la paleta (usos puntuales/decorativos) ---------- */
+  --color-accent-pink: #b83280;
+  --color-accent-purple: #8b00e9;
+  --color-accent-lime: #30aa00;
+  --color-accent-teal: #2980b9;
+  --color-accent-slate: #0f172a;
+  --color-accent-gray-warm: #6c757d;
+
+  /* ---------- Blancos / negro ---------- */
+  --color-white: #ffffff;
+  --color-black: #000000;
+
+  /* ---------- Color de borde ---------- */
+  --border-color: rgba(255, 255, 255, 0.15);
+
+  /* ---------- Equivalentes RGB (para usar dentro de rgba()) ---------- */
+  --shadow-color: 0, 0, 0;
+  --color-primary-rgb: 43, 108, 176;
+  --color-primary-hover-rgb: 66, 153, 225;
+  --color-success-rgb: 56, 161, 105;
+  --color-danger-rgb: 197, 48, 48;
+  --color-warning-rgb: 221, 107, 32;
+  --color-slate-rgb: 15, 23, 42;
+  --color-gray-800-rgb: 31, 41, 55;
+  --color-gray-900-rgb: 17, 24, 39;
+  --color-teal-rgb: 52, 152, 219;
+  --color-white-rgb: 252, 252, 252;
+  --color-navy-rgb: 2, 6, 23;
+  --color-slate-800-rgb: 16, 24, 40;
+  --color-navy-light-rgb: 15, 45, 75;
+  --color-navy-dark-rgb: 11, 18, 32;
+  --color-surface-dark-900-rgb: 0, 21, 43;
+  --color-blue-bright-rgb: 0, 123, 255;
+
+  /* ---------- Sombras genéricas (a partir de negro) ---------- */
+  --shadow-sm: 0 1px 3px rgba(var(--shadow-color), 0.08);
+  --shadow-md: 0 4px 12px rgba(var(--shadow-color), 0.1);
+  --shadow-lg: 0 10px 40px rgba(var(--shadow-color), 0.15);
+
+  /* Foco / sombras en color primario (botones, inputs, etc) */
+
+  /* ---------- Espaciados (escala base 4px) ---------- */
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 20px;
+  --space-6: 24px;
+  --space-7: 30px;
+  --space-8: 40px;
+
+  /* ---------- Tamaños de fuente ---------- */
+  --font-size-xs: 12px;
+  --font-size-sm: 14px;
+  --font-size-md: 16px;
+  --font-size-lg: 18px;
+  --font-size-xl: 20px;
+  --font-size-2xl: 26px;
+  --font-size-3xl: 35px;
+
+  /* ---------- Radios de borde ---------- */
+  --radius-sm: 6px;
+  --radius-md: 12px;
+  --radius-lg: 24px;
+  --radius-full: 999px;
+
+  /* ---------- Transiciones ---------- */
+  --transition-fast: 0.25s;
+}


### PR DESCRIPTION
- Crear src/FRONT/views/tokens.css con variables para toda la paleta de colores, espaciados, tamaños de fuente, radios y transiciones
- Reemplazar valores hardcodeados (hex, rgba, keywords white/black/red) en los 30 módulos CSS y en estilos inline de componentes
- Eliminar bloque de CSS muerto sin uso (boilerplate .logo/.card de Vite)